### PR TITLE
Fix netplan backup directory assignment

### DIFF
--- a/rke2nodeinit.sh
+++ b/rke2nodeinit.sh
@@ -449,7 +449,7 @@ EOF
 purge_old_netplan() {
   # back up and remove all existing netplan YAMLs to avoid merged old configs
   local bdir
-  bdir=$("/etc/netplan/.backup-$(date -u +%Y%m%dT%H%M%SZ)")
+  bdir="/etc/netplan/.backup-$(date -u +%Y%m%dT%H%M%SZ)"
   mkdir -p "$bdir"
   shopt -s nullglob
   local moved=0


### PR DESCRIPTION
## Summary
- correct the netplan backup directory assignment in purge_old_netplan to use standard variable syntax

## Testing
- /tmp/test_netplan.sh

------
https://chatgpt.com/codex/tasks/task_e_68de753b3ed083318ce97c6ff12a0ae6