### PR TITLE
Add token generation helper Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+# Utility helpers for project maintenance.
+#
+# Usage:
+#   make token [TOKEN_SIZE=24]
+#
+# TOKEN_SIZE controls the number of random bytes (default: 12) used when
+# generating the base64 token. The resulting token is echoed to stdout and
+# persisted under outputs/generated-token/ with the invocation timestamp.
+
+SHELL := /bin/bash
+TOKEN_SIZE ?= 12
+TOKEN_OUTPUT_DIR := outputs/generated-token
+TOKEN_TIMESTAMP := $(shell date +%Y%m%d-%H%M%S)
+TOKEN_FILE := $(TOKEN_OUTPUT_DIR)/token-$(TOKEN_TIMESTAMP).txt
+
+.PHONY: token
+## Generate a reusable base64 token and persist it for later use.
+token:
+	@set -euo pipefail; \
+		install -d -m 700 $(TOKEN_OUTPUT_DIR); \
+		TOKEN="$$(openssl rand -base64 $(TOKEN_SIZE))"; \
+		TOKEN_FILE="$(TOKEN_FILE)"; \
+		printf '%s\n' "$$TOKEN" | tee "$$TOKEN_FILE"; \
+		chmod 600 "$$TOKEN_FILE"; \
+		echo "Saved token to $$TOKEN_FILE" >&2

--- a/README.md
+++ b/README.md
@@ -102,6 +102,11 @@ sudo ./rke2nodeinit.sh -f clusters/prod-server.yaml -P server
 | `--dry-push` | Simulate `push` without contacting the registry |
 | `-h` | Display built-in help |
 
+### Makefile Helpers
+
+- `make token` generates a base64 token using OpenSSL. Override the byte length with `TOKEN_SIZE=<n>` (default `12`) to control the entropy, for example `make token TOKEN_SIZE=24`.
+- Each invocation prints the token to stdout and stores it under `outputs/generated-token/token-<YYYYMMDD-HHMMSS>.txt` with restrictive permissions so it can be reused later.
+
 ---
 
 ## YAML Configuration Reference

--- a/README.md
+++ b/README.md
@@ -6,20 +6,25 @@
 
 ## Table of Contents
 
-1. [Key Capabilities](#key-capabilities)
-2. [Supported Platforms & Requirements](#supported-platforms--requirements)
-3. [Workflow Overview](#workflow-overview)
-4. [Actions Breakdown](#actions-breakdown)
-5. [Command Reference](#command-reference)
-6. [YAML Configuration Reference](#yaml-configuration-reference)
-7. [Offline Registry & CA Handling](#offline-registry--ca-handling)
-8. [Network Configuration Strategy](#network-configuration-strategy)
-9. [Logging & Observability](#logging--observability)
-10. [Safety Controls & Idempotency](#safety-controls--idempotency)
-11. [Generated Files & Directory Layout](#generated-files--directory-layout)
-12. [Verification & Troubleshooting](#verification--troubleshooting)
-13. [Maintenance & Rollback Tips](#maintenance--rollback-tips)
-14. [Appendix: Environment Variables](#appendix-environment-variables)
+- [rke2nodeinit.sh](#rke2nodeinitsh)
+  - [Table of Contents](#table-of-contents)
+  - [Key Capabilities](#key-capabilities)
+  - [Supported Platforms \& Requirements](#supported-platforms--requirements)
+  - [Workflow Overview](#workflow-overview)
+  - [Actions Breakdown](#actions-breakdown)
+  - [Command Reference](#command-reference)
+    - [Common Flags](#common-flags)
+    - [Makefile Helpers](#makefile-helpers)
+  - [Development Helpers](#development-helpers)
+  - [YAML Configuration Reference](#yaml-configuration-reference)
+  - [Offline Registry \& CA Handling](#offline-registry--ca-handling)
+  - [Network Configuration Strategy](#network-configuration-strategy)
+  - [Logging \& Observability](#logging--observability)
+  - [Safety Controls \& Idempotency](#safety-controls--idempotency)
+  - [Generated Files \& Directory Layout](#generated-files--directory-layout)
+  - [Verification \& Troubleshooting](#verification--troubleshooting)
+  - [Maintenance \& Rollback Tips](#maintenance--rollback-tips)
+  - [Appendix: Environment Variables](#appendix-environment-variables)
 
 ---
 
@@ -107,7 +112,11 @@ sudo ./rke2nodeinit.sh -f clusters/prod-server.yaml -P server
 - `make token` generates a base64 token using OpenSSL. Override the byte length with `TOKEN_SIZE=<n>` (default `12`) to control the entropy, for example `make token TOKEN_SIZE=24`.
 - Each invocation prints the token to stdout and stores it under `outputs/generated-token/token-<YYYYMMDD-HHMMSS>.txt` with restrictive permissions so it can be reused later.
 
----
+## Development Helpers
+
+- **Generate reusable random tokens** – Run `make token` to print a fresh Base64 token and save it under
+  `outputs/generated-token/token-<timestamp>.txt`. Override the number of random bytes (default `12`) by
+  supplying `TOKEN_SIZE`, for example: `make token TOKEN_SIZE=24`.
 
 ## YAML Configuration Reference
 


### PR DESCRIPTION
## Summary
- add a repository Makefile with a reusable `token` helper target
- document the new helper in the README, including override and output details

## Testing
- make token TOKEN_SIZE=16


------
https://chatgpt.com/codex/tasks/task_e_68e02e4f5fe0833196c63ec8a1eb54b9