### PR TITLE
Ensure add-server action honors TLS SAN values from config

### DIFF
--- a/rke2nodeinit.sh
+++ b/rke2nodeinit.sh
@@ -2931,7 +2931,8 @@ action_add_server() {
   load_site_defaults
 
   local IP="" PREFIX="" HOSTNAME="" DNS="" SEARCH="" GW=""
-  local URL="" TOKEN_FILE="" TLS_SANS="" TOKEN=""
+  local URL="" TOKEN_FILE="" TOKEN=""
+  local TLS_SANS_IN="" TLS_SANS=""
 
   if [[ -n "$CONFIG_FILE" ]]; then
     IP="$(yaml_spec_get "$CONFIG_FILE" ip || true)"
@@ -2944,7 +2945,7 @@ action_add_server() {
     URL="$(yaml_spec_get_any "$CONFIG_FILE" serverURL server url || true)"
     TOKEN="$(yaml_spec_get "$CONFIG_FILE" token || true)"
     TOKEN_FILE="$(yaml_spec_get "$CONFIG_FILE" tokenFile || true)"
-    ts="$(yaml_spec_get_any "$CONFIG_FILE" tlsSans tls-san || true)"; [[ -z "$ts" ]] && ts="$(yaml_spec_list_csv "$CONFIG_FILE" tls-san || true)"; [[ -n "$ts" ]] && TLS_SANS_IN="$(normalize_list_csv "$ts")"
+    ts="$(yaml_spec_get_any "$CONFIG_FILE" tlsSans tls-san || true)"; [[ -z "$ts" ]] && ts="$(yaml_spec_list_csv "$CONFIG_FILE" tls-san || true)"; [[ -n "$ts" ]] && { TLS_SANS_IN="$(normalize_list_csv "$ts")"; TLS_SANS="$TLS_SANS_IN"; }
     load_custom_ca_from_config "$CONFIG_FILE"
   fi
 
@@ -2993,13 +2994,16 @@ action_add_server() {
   fi
 
   # Derive TLS SANs if not provided
-  local TLS_SANS_IN TLS_SANS
-  TLS_SANS_IN="$(yaml_spec_get "$CONFIG_FILE" tlsSans || true)"
-  if [[ -n "$TLS_SANS_IN" ]]; then
-    TLS_SANS="$(normalize_list_csv "$TLS_SANS_IN")"
-  else
-    TLS_SANS="$(_autosan_csv "$HOSTNAME" "$IP" "$SEARCH")"
-    log INFO "Auto-derived TLS SANs: $TLS_SANS"
+  if [[ -z "$TLS_SANS" ]]; then
+    if [[ -z "$TLS_SANS_IN" && -n "${CONFIG_FILE:-}" ]]; then
+      TLS_SANS_IN="$(yaml_spec_get "$CONFIG_FILE" tlsSans || true)"
+      [[ -z "$TLS_SANS_IN" ]] && TLS_SANS_IN="$(yaml_spec_list_csv "$CONFIG_FILE" tls-san || true)"
+      [[ -n "$TLS_SANS_IN" ]] && TLS_SANS="$(normalize_list_csv "$TLS_SANS_IN")"
+    fi
+    if [[ -z "$TLS_SANS" ]]; then
+      TLS_SANS="$(_autosan_csv "$HOSTNAME" "$IP" "$SEARCH")"
+      log INFO "Auto-derived TLS SANs: $TLS_SANS"
+    fi
   fi
 
   # Write RKE2 config for join
@@ -3009,7 +3013,7 @@ action_add_server() {
     : > /etc/rancher/rke2/config.yaml
   fi
   {
-    echo "server: \"$SERVER_URL\""     # required
+    echo "server: \"$URL\""     # required
     echo "token: $TOKEN"           # required
     echo "node-ip: \"$IP\""
     _emit_tls_san_yaml "$TLS_SANS"


### PR DESCRIPTION
## Summary
- preserve TLS SAN values loaded from YAML when running the add-server action
- fall back to auto-generated SANs only when none are provided in config or prompts
- fix the join configuration to write the parsed server URL

## Testing
- bash -n rke2nodeinit.sh

------
https://chatgpt.com/codex/tasks/task_e_68e2b0d9d2a083318e34d4728d92b947