### PR TITLE
codex-v1_Fix add-server config rendering

### DIFF
--- a/clusters/copine/copine-ctrl01.yaml
+++ b/clusters/copine/copine-ctrl01.yaml
@@ -13,7 +13,7 @@ spec:
   write-kubeconfig-mode: "0640"
   tls-san:
     - copine-ctrl01
-    - copine-ctrl01.cantrellcloud.net
+    - copine-ctrl01.k8.cantrellcloud.net
     - 10.0.69.55
   node-taint:
   - "node-role.kubernetes.io/control-plane:NoSchedule"

--- a/clusters/cotpa/cotpa-ctrl01.yaml
+++ b/clusters/cotpa/cotpa-ctrl01.yaml
@@ -10,15 +10,15 @@ spec:
   hostname: cotpa-ctrl01
   dns: ["172.16.69.71", "172.16.69.72"]
   searchDomains: ["cantrellcloud.net", "cantrelloffice.cloud"]
-
-
   write-kubeconfig-mode: "0640"
   tls-san:
     - cotpa-ctrl01
-    - cotpa-ctrl01.cantrellcloud.net
+    - cotpa-ctrl01.k8.cantrellcloud.net
+    - cotpa-cluster
+    - cotpa-cluster.k8.cantrellcloud.net
     - 172.16.15.131
-  node-taint:
-  - "node-role.kubernetes.io/control-plane:NoSchedule"
+ # node-taint:
+ # - "node-role.kubernetes.io/control-plane:NoSchedule"
   node-label:
   - "env=preprod"
   service-cidr: 10.96.0.0/12
@@ -28,7 +28,6 @@ spec:
   enable-servicelb: false
   kube-apiserver-arg:
     - audit-log-maxage=15
-
   # Optional: your CA handling
   customCA:
     rootCrt: certs/rke2ca-cert.crt

--- a/clusters/cotpa/cotpa-ctrl02.yaml
+++ b/clusters/cotpa/cotpa-ctrl02.yaml
@@ -11,26 +11,19 @@ spec:
   dns: ["172.16.69.71", "172.16.69.72"]
   searchDomains: ["cantrellcloud.net", "cantrelloffice.cloud"]
   serverURL: https://172.16.15.131:9345
-
   write-kubeconfig-mode: "0640"
   tls-san:
     - cotpa-ctrl02
-    - cotpa-ctrl02.cantrellcloud.net
+    - cotpa-ctrl02.k8.cantrellcloud.net
+    - cotpa-cluster
+    - cotpa-cluster.k8.cantrellcloud.net
     - 172.16.15.132
   node-taint:
   - "node-role.kubernetes.io/control-plane:NoSchedule"
   node-label:
   - "env=preprod"
-
+  service-cidr: 10.96.0.0/12
+  cluster-cidr: 10.42.0.0/16
+  cluster-domain: cluster.local
   kube-apiserver-arg:
     - audit-log-maxage=15
-
-  
-    
-    
-  
-  # Optional: your CA handling
-  customCA:
-    rootCrt: certs/rke2ca-cert.crt
-    rootKey: certs/rke2ca-cert-key.pem
-    installToOSTrust: true

--- a/clusters/cotpa/cotpa-work01.yaml
+++ b/clusters/cotpa/cotpa-work01.yaml
@@ -11,21 +11,6 @@ spec:
   dns: ["172.16.69.71", "172.16.69.72"]
   searchDomains: ["cantrellcloud.net", "cantrelloffice.cloud"]
   serverURL: https://172.16.15.131:9345
-
   node-label:
   - "role=worker"
   - "env=preprod"
-  
-  
-  
-  
-  
-  
-  
-    
-  
-  # Optional: your CA handling
-  customCA:
-    rootCrt: certs/rke2ca-cert.crt
-    rootKey: certs/rke2ca-cert-key.pem
-    installToOSTrust: true

--- a/rke2nodeinit.sh
+++ b/rke2nodeinit.sh
@@ -95,6 +95,7 @@ case "$ARCH" in
 esac
 
 DEFAULT_DNS="10.0.1.34,10.231.1.34"
+DEFAULT_SEARCH="svc.cluster.local,cluster.local"
 AUTO_YES=0                  # -y auto-confirm reboots and any legacy runtime cleanup if detected
 PRINT_CONFIG=0              # -P print sanitized YAML
 DRY_PUSH=0                  # --dry-push skips actual registry push

--- a/rke2nodeinit.sh
+++ b/rke2nodeinit.sh
@@ -2735,7 +2735,6 @@ action_server() {
     log INFO "Append additional keys from YAML spec (cluster-cidr, domain, cni, etc.)..." >&2
     append_spec_config_extras "$CONFIG_FILE"
 
-    #echo "TLS-SANs: $TLS_SANS"
     #log INFO "Emit TLS SANs..." >&2
     #emit_tls_sans "$TLS_SANS"
 
@@ -2747,7 +2746,6 @@ action_server() {
     fi
     echo "  - container-log-max-size=10Mi"
     echo "  - container-log-max-files=5"
-    echo "write-kubeconfig-mode: \"0640\""
 	echo "disable:"
 	echo "  - rke2-ingress-nginx"
 	echo
@@ -3057,8 +3055,11 @@ action_add_server() {
 	  log INFO "Using provided token file: $TOKEN_FILE..." >&2
     fi
 
-    log INFO "Emit TLS SANs..." >&2
-    emit_tls_sans "$TLS_SANS"
+    log INFO "Append additional keys from YAML spec (cluster-cidr, domain, cni, etc.)..." >&2
+    append_spec_config_extras "$CONFIG_FILE"
+
+    #log INFO "Emit TLS SANs..." >&2
+    #emit_tls_sans "$TLS_SANS"
 
     # Kubelet defaults (safe; additive). Merge-friendly if you later append more.
     echo "kubelet-arg:"
@@ -3074,10 +3075,6 @@ action_add_server() {
 	echo
 
   } >> /etc/rancher/rke2/config.yaml
-
-  log INFO "Append additional keys from YAML spec (cluster-cidr, domain, cni, etc.)..."
-  append_spec_config_extras "$CONFIG_FILE"
-
   log INFO "Wrote /etc/rancher/rke2/config.yaml"
 
   log INFO "Setting file security: chmod 600 /etc/rancher/rke2/config.yaml..."

--- a/rke2nodeinit.sh
+++ b/rke2nodeinit.sh
@@ -2720,7 +2720,7 @@ action_server() {
 
   : > /etc/rancher/rke2/config.yaml
   {
-    log INFO "Setting debug..."
+    log INFO "Setting debug..." >&2
     echo "debug: true"
 
     log INFO "Get token..." >&2
@@ -2732,8 +2732,11 @@ action_server() {
 	  log INFO "Using provided token file: $TOKEN_FILE..." >&2
     fi
 
-    echo "TLS-SANs: $TLS_SANS"
-    log INFO "Emit TLS SANs..." >&2
+    log INFO "Append additional keys from YAML spec (cluster-cidr, domain, cni, etc.)..." >&2
+    append_spec_config_extras "$CONFIG_FILE"
+
+    #echo "TLS-SANs: $TLS_SANS"
+    #log INFO "Emit TLS SANs..." >&2
     #emit_tls_sans "$TLS_SANS"
 
     # Kubelet defaults (safe; additive). Merge-friendly if you later append more.
@@ -2750,10 +2753,6 @@ action_server() {
 	echo
 
   } >> /etc/rancher/rke2/config.yaml
-
-  log INFO "Append additional keys from YAML spec (cluster-cidr, domain, cni, etc.)..."
-  append_spec_config_extras "$CONFIG_FILE"
-
   log INFO "Wrote /etc/rancher/rke2/config.yaml"
 
   log INFO "Setting file security: chmod 600 /etc/rancher/rke2/config.yaml..."

--- a/rke2nodeinit.sh
+++ b/rke2nodeinit.sh
@@ -2723,16 +2723,16 @@ action_server() {
     log INFO "Setting debug..."
     echo "debug: true"
 
-    log INFO "Get token..." 2>&1
+    log INFO "Get token..." >&2
     if [[ -n "$TOKEN" ]]; then
       echo "token: $TOKEN"
-	  log INFO "Using provided token..." 2>&1
+	  log INFO "Using provided token..." >&2
     elif [[ -n "$TOKEN_FILE" ]]; then
       echo "token-file: \"$TOKEN_FILE\""
-	  log INFO "Using provided token file: $TOKEN_FILE..." 2>&1
+	  log INFO "Using provided token file: $TOKEN_FILE..." >&2
     fi
 
-    log INFO "Emit TLS SANs..." 2>&1
+    log INFO "Emit TLS SANs..." >&2
     emit_tls_sans "$TLS_SANS"
 
     # Kubelet defaults (safe; additive). Merge-friendly if you later append more.
@@ -2743,7 +2743,6 @@ action_server() {
     fi
     echo "  - container-log-max-size=10Mi"
     echo "  - container-log-max-files=5"
-   # echo "  - protect-kernel-defaults=true"
     echo "write-kubeconfig-mode: \"0640\""
 	echo "disable:"
 	echo "  - rke2-ingress-nginx"
@@ -2759,6 +2758,7 @@ action_server() {
   log INFO "Setting file security: chmod 600 /etc/rancher/rke2/config.yaml..."
   chmod 600 /etc/rancher/rke2/config.yaml
   
+  log INFO "Writing netplan configuration and applying network settings..."
   write_netplan "$IP" "$PREFIX" "${GW:-}" "${DNS:-}" "${SEARCH:-}"
 
   log INFO "Installing rke2-server from cache at $STAGE_DIR"
@@ -3042,22 +3042,22 @@ action_add_server() {
 
   : > /etc/rancher/rke2/config.yaml
   {
-    log INFO "Setting debug..." 2>&1
+    log INFO "Setting debug..." >&2
     echo "debug: true"
 
-    log INFO "Setting server URL..." 2>&1
+    log INFO "Setting server URL..." >&2
     echo "server: \"$URL\""     # required
 
-    log INFO "Get token..." 2>&1
+    log INFO "Get token..." >&2
     if [[ -n "$TOKEN" ]]; then
       echo "token: $TOKEN"
-	  log INFO "Using provided token..." 2>&1
+	  log INFO "Using provided token..." >&2
     elif [[ -n "$TOKEN_FILE" ]]; then
       echo "token-file: \"$TOKEN_FILE\""
-	  log INFO "Using provided token file: $TOKEN_FILE..." 2>&1
+	  log INFO "Using provided token file: $TOKEN_FILE..." >&2
     fi
 
-    log INFO "Emit TLS SANs..." 2>&1
+    log INFO "Emit TLS SANs..." >&2
     emit_tls_sans "$TLS_SANS"
 
     # Kubelet defaults (safe; additive). Merge-friendly if you later append more.
@@ -3068,7 +3068,6 @@ action_add_server() {
     fi
     echo "  - container-log-max-size=10Mi"
     echo "  - container-log-max-files=5"
-   # echo "  - protect-kernel-defaults=true"
     echo "write-kubeconfig-mode: \"0640\""
 	echo "disable:"
 	echo "  - rke2-ingress-nginx"
@@ -3084,6 +3083,7 @@ action_add_server() {
   log INFO "Setting file security: chmod 600 /etc/rancher/rke2/config.yaml..."
   chmod 600 /etc/rancher/rke2/config.yaml
 
+  log INFO "Writing netplan configuration and applying network settings..."
   write_netplan "$IP" "$PREFIX" "${GW:-}" "${DNS:-}" "${SEARCH:-}"
 
   log INFO "Installing rke2-server from cache at $STAGE_DIR"
@@ -3092,7 +3092,6 @@ action_add_server() {
 
   echo
   echo "[READY] rke2-server installed. Reboot to initialize the control plane."
-  echo "        First server token: /var/lib/rancher/rke2/server/node-token"
   echo
   prompt_reboot
 }

--- a/rke2nodeinit.sh
+++ b/rke2nodeinit.sh
@@ -2732,8 +2732,9 @@ action_server() {
 	  log INFO "Using provided token file: $TOKEN_FILE..." >&2
     fi
 
+    echo "TLS-SANs: $TLS_SANS"
     log INFO "Emit TLS SANs..." >&2
-    emit_tls_sans "$TLS_SANS"
+    #emit_tls_sans "$TLS_SANS"
 
     # Kubelet defaults (safe; additive). Merge-friendly if you later append more.
     echo "kubelet-arg:"

--- a/rke2nodeinit.sh
+++ b/rke2nodeinit.sh
@@ -2644,6 +2644,7 @@ action_server() {
     sd="$(yaml_spec_get "$CONFIG_FILE" searchDomains || true)"; [[ -n "$sd" ]] && SEARCH="$(normalize_list_csv "$sd")"
     ts="$(yaml_spec_get_any "$CONFIG_FILE" tlsSans tls-san || true)"; [[ -z "$ts" ]] && ts="$(yaml_spec_list_csv "$CONFIG_FILE" tls-san || true)"; [[ -n "$ts" ]] && TLS_SANS_IN="$(normalize_list_csv "$ts")"
     TOKEN="$(yaml_spec_get "$CONFIG_FILE" token || true)"
+    TOKEN_FILE="$(yaml_spec_get "$CONFIG_FILE" tokenFile || true)"
     load_custom_ca_from_config "$CONFIG_FILE"
   fi
 
@@ -2657,7 +2658,9 @@ action_server() {
     read -rp "Enter DNS IPv4s (comma-separated) [blank=default ${DEFAULT_DNS}]: " DNS || true
     [[ -z "$DNS" ]] && DNS="$DEFAULT_DNS"
   fi
-  [[ -z "$SEARCH" && -n "${DEFAULT_SEARCH:-}" ]] && SEARCH="$DEFAULT_SEARCH"
+  if [[ -z "$SEARCH" && -n "${DEFAULT_SEARCH:-}" ]]; then
+    SEARCH="$DEFAULT_SEARCH"
+  fi
 
   log INFO "Validating configuration..."
   # Validate
@@ -2669,11 +2672,18 @@ action_server() {
   [[ -z "${PREFIX:-}" ]] && PREFIX=24
 
   # Auto-derive tls-sans if none provided in YAML
-  if [[ -n "$TLS_SANS_IN" ]]; then
-    TLS_SANS="$TLS_SANS_IN"
-  else
-    TLS_SANS="$(capture_sans "$HOSTNAME" "$IP" "$SEARCH")"
-    log INFO "Auto-derived TLS SANs: $TLS_SANS"
+  log INFO "Determining TLS SANs..."
+  if [[ -z "$TLS_SANS" ]]; then
+    if [[ -z "$TLS_SANS_IN" && -n "${CONFIG_FILE:-}" ]]; then
+      TLS_SANS_IN="$(yaml_spec_get "$CONFIG_FILE" tlsSans || true)"
+      [[ -z "$TLS_SANS_IN" ]] && TLS_SANS_IN="$(yaml_spec_list_csv "$CONFIG_FILE" tls-san || true)"
+      [[ -n "$TLS_SANS_IN" ]] && TLS_SANS="$(normalize_list_csv "$TLS_SANS_IN")"
+	  log INFO "TLS SANs from config: $TLS_SANS"
+    fi
+    if [[ -z "$TLS_SANS" ]]; then
+      TLS_SANS="$(capture_sans "$HOSTNAME" "$IP" "$SEARCH")"
+      log INFO "Auto-derived TLS SANs: $TLS_SANS"
+    fi
   fi
 
   log INFO "Ensuring staged artifacts for offline RKE2 server install..."
@@ -2683,8 +2693,10 @@ action_server() {
   hostnamectl set-hostname "$HOSTNAME"
   if ! grep -qE "[[:space:]]$HOSTNAME(\$|[[:space:]])" /etc/hosts; then echo "$IP $HOSTNAME" >> /etc/hosts; fi
 
+  log INFO "Seeding custom cluster CA (if first server in a cluster; safe to skip on join)..."
   setup_custom_cluster_ca || true
 
+  log INFO "Validating/expanding provided token (if any)..."
   if [[ -n "$TOKEN" ]]; then
     local full_token
     full_token="$(ensure_full_cluster_token "$TOKEN")"
@@ -2708,15 +2720,19 @@ action_server() {
 
   : > /etc/rancher/rke2/config.yaml
   {
+    log INFO "Setting debug..."
     echo "debug: true"
-    #echo "cluster-init: $cluster_init_value"
 
-    # Optional but recommended: stable join secret for future nodes
+    log INFO "Get token..." 2>&1
     if [[ -n "$TOKEN" ]]; then
       echo "token: $TOKEN"
+	  log INFO "Using provided token..." 2>&1
+    elif [[ -n "$TOKEN_FILE" ]]; then
+      echo "token-file: \"$TOKEN_FILE\""
+	  log INFO "Using provided token file: $TOKEN_FILE..." 2>&1
     fi
 
-    echo "node-ip: \"$IP\""
+    log INFO "Emit TLS SANs..." 2>&1
     emit_tls_sans "$TLS_SANS"
 
     # Kubelet defaults (safe; additive). Merge-friendly if you later append more.
@@ -2928,31 +2944,33 @@ action_agent() {
 # ------------------------------------------------------------------------------
 action_add_server() {
   initialize_action_context false "add-server"
+  log INFO "Ensure YAML has metadata.name..."
 
+  log INFO "Loading site defaults..."
   load_site_defaults
 
-  local IP="" PREFIX="" HOSTNAME="" DNS="" SEARCH="" GW=""
-  local URL="" TOKEN_FILE="" TOKEN=""
-  local TLS_SANS_IN="" TLS_SANS=""
+  local IP="" PREFIX="" HOSTNAME="" DNS="" SEARCH=""
+  local TLS_SANS_IN="" TLS_SANS="" TOKEN="" GW=""
+  local URL="" TOKEN_FILE=""
 
   if [[ -n "$CONFIG_FILE" ]]; then
     IP="$(yaml_spec_get "$CONFIG_FILE" ip || true)"
     PREFIX="$(yaml_spec_get "$CONFIG_FILE" prefix || true)"
     HOSTNAME="$(yaml_spec_get "$CONFIG_FILE" hostname || true)"
+    GW="$(yaml_spec_get "$CONFIG_FILE" gateway || true)"
     local d sd ts
     d="$(yaml_spec_get "$CONFIG_FILE" dns || true)"; [[ -n "$d" ]] && DNS="$(normalize_list_csv "$d")"
     sd="$(yaml_spec_get "$CONFIG_FILE" searchDomains || true)"; [[ -n "$sd" ]] && SEARCH="$(normalize_list_csv "$sd")"
-    GW="$(yaml_spec_get "$CONFIG_FILE" gateway || true)"
-    URL="$(yaml_spec_get_any "$CONFIG_FILE" serverURL server url || true)"
+    ts="$(yaml_spec_get_any "$CONFIG_FILE" tlsSans tls-san || true)"; [[ -z "$ts" ]] && ts="$(yaml_spec_list_csv "$CONFIG_FILE" tls-san || true)"; [[ -n "$ts" ]] && { TLS_SANS_IN="$(normalize_list_csv "$ts")"; TLS_SANS="$TLS_SANS_IN"; }
     TOKEN="$(yaml_spec_get "$CONFIG_FILE" token || true)"
     TOKEN_FILE="$(yaml_spec_get "$CONFIG_FILE" tokenFile || true)"
-    ts="$(yaml_spec_get_any "$CONFIG_FILE" tlsSans tls-san || true)"; [[ -z "$ts" ]] && ts="$(yaml_spec_list_csv "$CONFIG_FILE" tls-san || true)"; [[ -n "$ts" ]] && { TLS_SANS_IN="$(normalize_list_csv "$ts")"; TLS_SANS="$TLS_SANS_IN"; }
+    URL="$(yaml_spec_get_any "$CONFIG_FILE" serverURL server url || true)"
     load_custom_ca_from_config "$CONFIG_FILE"
   fi
 
+  [[ -z "$HOSTNAME" ]] && HOSTNAME="$(hostnamectl --static 2>/dev/null || hostname)"
   [[ -z "$IP"       ]] && read -rp "Enter static IPv4 for this server node: " IP
   [[ -z "$PREFIX"   ]] && read -rp "Enter subnet prefix length (0-32) [default 24]: " PREFIX
-  [[ -z "$HOSTNAME" ]] && read -rp "Enter hostname for this server node: " HOSTNAME
   [[ -z "$GW"       ]] && read -rp "Enter default gateway IPv4 [leave blank to skip]: " GW || true
 
   if [[ -z "$DNS" ]]; then
@@ -2963,17 +2981,8 @@ action_add_server() {
     SEARCH="$DEFAULT_SEARCH"
   fi
 
-  # Cluster join info
-  [[ -z "$URL" ]] && read -rp "Enter EXISTING RKE2 server URL (e.g. https://<vip-or-node>:9345): " URL
-  if [[ -z "$TOKEN" && -z "$TOKEN_FILE" ]]; then
-    read -rp "Enter cluster join token (leave blank to provide a token file path): " TOKEN || true
-    if [[ -z "$TOKEN" ]]; then
-      read -rp "Enter path to token file (e.g., /var/lib/rancher/rke2/server/node-token): " TOKEN_FILE || true
-    fi
-  fi
-  [[ -z "$TLS_SANS" ]] && read -rp "Optional TLS SANs (CSV; hostnames/IPs) [blank=skip]: " TLS_SANS || true
-
-  # Validation
+  log INFO "Validating configuration..."
+  # Validate
   while ! valid_ipv4 "$IP"; do read -rp "Invalid IPv4. Re-enter server IP: " IP; done
   while ! valid_prefix "${PREFIX:-}"; do read -rp "Invalid prefix (0-32). Re-enter server prefix [default 24]: " PREFIX; done
   while ! valid_ipv4_or_blank "${GW:-}"; do read -rp "Invalid gateway IPv4 (or blank). Re-enter: " GW; done
@@ -2981,8 +2990,32 @@ action_add_server() {
   while ! valid_search_domains_csv "${SEARCH:-}"; do read -rp "Invalid search domain list. Re-enter CSV: " SEARCH; done
   [[ -z "${PREFIX:-}" ]] && PREFIX=24
 
+  # Auto-derive tls-sans if none provided in YAML
+  log INFO "Determining TLS SANs..."
+  if [[ -z "$TLS_SANS" ]]; then
+    if [[ -z "$TLS_SANS_IN" && -n "${CONFIG_FILE:-}" ]]; then
+      TLS_SANS_IN="$(yaml_spec_get "$CONFIG_FILE" tlsSans || true)"
+      [[ -z "$TLS_SANS_IN" ]] && TLS_SANS_IN="$(yaml_spec_list_csv "$CONFIG_FILE" tls-san || true)"
+      [[ -n "$TLS_SANS_IN" ]] && TLS_SANS="$(normalize_list_csv "$TLS_SANS_IN")"
+	  log INFO "TLS SANs from config: $TLS_SANS"
+    fi
+    if [[ -z "$TLS_SANS" ]]; then
+      TLS_SANS="$(capture_sans "$HOSTNAME" "$IP" "$SEARCH")"
+      log INFO "Auto-derived TLS SANs: $TLS_SANS"
+    fi
+  fi
+
+  log INFO "Ensuring staged artifacts for offline RKE2 server install..."
   ensure_staged_artifacts
 
+  log INFO "Setting new hostname: $HOSTNAME..."
+  hostnamectl set-hostname "$HOSTNAME"
+  if ! grep -qE "[[:space:]]$HOSTNAME(\$|[[:space:]])" /etc/hosts; then echo "$IP $HOSTNAME" >> /etc/hosts; fi
+
+  log INFO "Seeding custom cluster CA (if first server in a cluster; safe to skip on join)..."
+  setup_custom_cluster_ca || true
+
+  log INFO "Validating/expanding provided token (if any)..."
   if [[ -n "$TOKEN" ]]; then
     local full_token=""
     full_token="$(ensure_full_cluster_token "$TOKEN")"
@@ -2994,87 +3027,74 @@ action_add_server() {
     fi
   fi
 
-  # Derive TLS SANs if not provided
-  if [[ -z "$TLS_SANS" ]]; then
-    if [[ -z "$TLS_SANS_IN" && -n "${CONFIG_FILE:-}" ]]; then
-      TLS_SANS_IN="$(yaml_spec_get "$CONFIG_FILE" tlsSans || true)"
-      [[ -z "$TLS_SANS_IN" ]] && TLS_SANS_IN="$(yaml_spec_list_csv "$CONFIG_FILE" tls-san || true)"
-      [[ -n "$TLS_SANS_IN" ]] && TLS_SANS="$(normalize_list_csv "$TLS_SANS_IN")"
-    fi
-    if [[ -z "$TLS_SANS" ]]; then
-      TLS_SANS="$(capture_sans "$HOSTNAME" "$IP" "$SEARCH")"
-      log INFO "Auto-derived TLS SANs: $TLS_SANS"
+  log INFO "Gathering cluster join information..."
+  [[ -z "$URL" ]] && read -rp "Enter EXISTING RKE2 server URL (e.g. https://<vip-or-node>:9345): " URL
+  if [[ -z "$TOKEN" && -z "$TOKEN_FILE" ]]; then
+    read -rp "Enter cluster join token (leave blank to provide a token file path): " TOKEN || true
+    if [[ -z "$TOKEN" ]]; then
+      read -rp "Enter path to token file (e.g., /var/lib/rancher/rke2/server/node-token): " TOKEN_FILE || true
     fi
   fi
+  [[ -z "$TLS_SANS" ]] && read -rp "Optional TLS SANs (CSV; hostnames/IPs) [blank=skip]: " TLS_SANS || true
 
-  # Write RKE2 config for join
+  log INFO "Writing file: /etc/rancher/rke2/config.yaml..."
   mkdir -p /etc/rancher/rke2
-  local cfg="/etc/rancher/rke2/config.yaml"
-  local preserved_tmp=""
-  if [[ -f "$cfg" ]]; then
-    preserved_tmp="$(mktemp)"
-    awk '
-      BEGIN { skip = 0 }
-      /^[[:space:]]*server:[[:space:]]/ { next }
-      /^[[:space:]]*token(-file)?:[[:space:]]/ { next }
-      /^[[:space:]]*node-(ip|name):[[:space:]]/ { next }
-      /^[[:space:]]*write-kubeconfig-mode:[[:space:]]/ { next }
-      /^[[:space:]]*kubelet-arg:[[:space:]]*$/ { skip = 1; next }
-      skip == 1 {
-        if ($0 ~ /^[[:space:]]*-/) { next }
-        if ($0 ~ /^[[:space:]]*$/) { next }
-        skip = 0
-      }
-      { print }
-    ' "$cfg" > "$preserved_tmp"
-  fi
 
-  : > "$cfg"
-  if [[ -n "$preserved_tmp" && -s "$preserved_tmp" ]]; then
-    cat "$preserved_tmp" >> "$cfg"
-    echo >> "$cfg"
-  fi
-
+  : > /etc/rancher/rke2/config.yaml
   {
+    log INFO "Setting debug..." 2>&1
+    echo "debug: true"
+
+    log INFO "Setting server URL..." 2>&1
     echo "server: \"$URL\""     # required
+
+    log INFO "Get token..." 2>&1
     if [[ -n "$TOKEN" ]]; then
       echo "token: $TOKEN"
+	  log INFO "Using provided token..." 2>&1
     elif [[ -n "$TOKEN_FILE" ]]; then
       echo "token-file: \"$TOKEN_FILE\""
+	  log INFO "Using provided token file: $TOKEN_FILE..." 2>&1
     fi
-    echo "node-ip: \"$IP\""
+
+    log INFO "Emit TLS SANs..." 2>&1
+    emit_tls_sans "$TLS_SANS"
+
+    # Kubelet defaults (safe; additive). Merge-friendly if you later append more.
     echo "kubelet-arg:"
+    # Prefer systemd-resolved if present
     if [[ -f /run/systemd/resolve/resolv.conf ]]; then
       echo "  - resolv-conf=/run/systemd/resolve/resolv.conf"
     fi
     echo "  - container-log-max-size=10Mi"
     echo "  - container-log-max-files=5"
-    echo "  - protect-kernel-defaults=true"
+   # echo "  - protect-kernel-defaults=true"
     echo "write-kubeconfig-mode: \"0640\""
-  } >> "$cfg"
-  chmod 600 "$cfg"
-  [[ -n "$preserved_tmp" ]] && rm -f "$preserved_tmp"
+	echo "disable:"
+	echo "  - rke2-ingress-nginx"
+	echo
 
-  # Append additional keys from YAML spec (cluster-cidr, domain, cni, etc.)
+  } >> /etc/rancher/rke2/config.yaml
+
+  log INFO "Append additional keys from YAML spec (cluster-cidr, domain, cni, etc.)..."
   append_spec_config_extras "$CONFIG_FILE"
-  log INFO "RKE2 join config written to /etc/rancher/rke2/config.yaml"
-  log INFO "server: $URL"
-  if [[ -n "$TOKEN_FILE" ]]; then log INFO "token_file: $TOKEN_FILE"; else log INFO "token: (redacted)"; fi
 
-  # Install rke2-server using staged artifacts
-  local SRC="$STAGE_DIR"
-  log INFO "Seeding custom cluster CA (if first server in a cluster; safe to skip on join)..."
-  setup_custom_cluster_ca || true
-  log INFO "Installing rke2-server (join existing control plane)..."
-  run_rke2_installer "$SRC" "server"
-  systemctl enable --now rke2-server >>"$LOG_FILE" 2>&1 || true
+  log INFO "Wrote /etc/rancher/rke2/config.yaml"
 
-  # Basic hostname and /etc/hosts
-  hostnamectl set-hostname "$HOSTNAME"
-  if ! grep -q "$HOSTNAME" /etc/hosts; then echo "$IP $HOSTNAME" >> /etc/hosts; fi
+  log INFO "Setting file security: chmod 600 /etc/rancher/rke2/config.yaml..."
+  chmod 600 /etc/rancher/rke2/config.yaml
 
   write_netplan "$IP" "$PREFIX" "${GW:-}" "${DNS:-}" "${SEARCH:-}"
-  echo "A reboot is recommended to ensure clean state. Network is already applied."
+
+  log INFO "Installing rke2-server from cache at $STAGE_DIR"
+  run_rke2_installer "$STAGE_DIR" "server"
+  systemctl enable rke2-server >>"$LOG_FILE" 2>&1 || true
+
+  echo
+  echo "[READY] rke2-server installed. Reboot to initialize the control plane."
+  echo "        First server token: /var/lib/rancher/rke2/server/node-token"
+  echo
+  prompt_reboot
 }
 
 # ==================

--- a/rke2nodeinit.sh
+++ b/rke2nodeinit.sh
@@ -3069,7 +3069,6 @@ action_add_server() {
     fi
     echo "  - container-log-max-size=10Mi"
     echo "  - container-log-max-files=5"
-    echo "write-kubeconfig-mode: \"0640\""
 	echo "disable:"
 	echo "  - rke2-ingress-nginx"
 	echo


### PR DESCRIPTION
## Summary
- filter existing config.yaml to drop stale join settings before writing the add-server configuration
- rewrite the add-server join block so it truncates the config, preserves non-join keys, and supports token-file fallback

## Testing
- bash -n rke2nodeinit.sh

------
https://chatgpt.com/codex/tasks/task_e_68e2efd950ec83318c2e7cc36980b80d