### PR TITLE
Honor CLI overrides and validate CustomCA action

### DIFF
--- a/certs/cotpa-ca.yaml
+++ b/certs/cotpa-ca.yaml
@@ -1,5 +1,5 @@
 apiVersion: rkeprep/v1
-kind: ClusterCA
+kind: CustomCA
 metadata:
   name: cotpa-cluster-ca
 spec:

--- a/certs/preprod-ca.yaml
+++ b/certs/preprod-ca.yaml
@@ -1,5 +1,5 @@
 apiVersion: rkeprep/v1
-kind: ClusterCA
+kind: CustomCA
 metadata:
   name: preprod-ca
 spec:

--- a/certs/rke2clusterCA.yaml
+++ b/certs/rke2clusterCA.yaml
@@ -1,5 +1,5 @@
 apiVersion: rkeprep/v1
-kind: ClusterCA
+kind: CustomCA
 metadata:
   name: rke2cluster-ca
 spec:

--- a/rke2nodeinit.sh
+++ b/rke2nodeinit.sh
@@ -62,7 +62,7 @@ esac
 #   - strong input validation for IP/prefix/DNS/search
 #
 # YAML (apiVersion: rkeprep/v1) kinds determine action when using -f <file>:
-#   - kind: Push|push, Image|image, Server|server, AddServer|add-server|addServer, Agent|agent, ClusterCA|cluster-ca
+#   - kind: Push|push, Image|image, Server|server, AddServer|add-server|addServer, Agent|agent, CustomCA|custom-ca|customca
 #
 # Exit codes:
 #   0 success | 1 usage | 2 missing prerequisites | 3 data missing | 4 registry auth | 5 YAML issues


### PR DESCRIPTION
## Summary
- add a reusable parser for action-specific CLI flags and apply the values after reading YAML but before prompting
- ensure server, agent, and add-server actions honor CLI fallbacks for network, token, and TLS inputs
- tighten CustomCA handling by resetting CA context, requiring kind CustomCA, and reading only spec.customca fields

## Testing
- bash -n rke2nodeinit.sh

------
https://chatgpt.com/codex/tasks/task_e_68e6a281623c8331947a04123c2621f3