### PR TITLE
Skip IPAM CI when app package is absent

### DIFF
--- a/.github/workflows/ipam-app-ci.yml
+++ b/.github/workflows/ipam-app-ci.yml
@@ -8,7 +8,6 @@ on:
       - 'Makefile'
       - 'docs/IPAM-APP.md'
       - 'docs/README.md'
-      - 'CONTRIBUTING.md'
 
 jobs:
   test:
@@ -19,16 +18,30 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Detect IPAM app package
+        id: detect-ipam
+        run: |
+          if [ -f apps/ipam/pyproject.toml ] || [ -f apps/ipam/setup.py ] || [ -f apps/ipam/setup.cfg ]; then
+            echo "has_ipam=true" >> "$GITHUB_OUTPUT"
+            echo "IPAM app package detected."
+          else
+            echo "has_ipam=false" >> "$GITHUB_OUTPUT"
+            echo "IPAM app package not present in this checkout; skipping IPAM dependency install and tests."
+          fi
+
       - name: Set up Python
+        if: steps.detect-ipam.outputs.has_ipam == 'true'
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 
       - name: Install dependencies
+        if: steps.detect-ipam.outputs.has_ipam == 'true'
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e ./apps/ipam[dev]
 
       - name: Run tests
+        if: steps.detect-ipam.outputs.has_ipam == 'true'
         run: |
           PYTHONPATH=apps/ipam/src python -m pytest apps/ipam/tests


### PR DESCRIPTION
## Problem Statement

The `IPAM App CI` workflow failed on the repository security policy PR during the `Install dependencies` step. The workflow was triggered by `CONTRIBUTING.md`, but the repository currently does not include an installable `apps/ipam` Python package on `main`, so `python -m pip install -e ./apps/ipam[dev]` can fail even when a PR only changes governance documentation.

## Technical Summary

- Removes `CONTRIBUTING.md` from the IPAM workflow path trigger.
- Adds an `Detect IPAM app package` step that checks for `apps/ipam/pyproject.toml`, `setup.py`, or `setup.cfg`.
- Runs Python setup, dependency install, and tests only when an installable IPAM package is present.
- Leaves the workflow active for real IPAM app changes and workflow changes.

## Validation Evidence

Failure observed in PR #71 workflow run:

```text
Workflow: IPAM App CI
Job: Test Internal IPAM App
Failed step: Install dependencies
```

The workflow currently installs:

```bash
python -m pip install -e ./apps/ipam[dev]
```

but code search did not show an installable `apps/ipam` package in the current repository state.

## Documentation Updated

Not required; this is a CI guard fix.

## Security And Sensitive Data Checklist

- [x] No private keys, kubeconfigs, tokens, registry passwords, or production credentials are committed.
- [x] No production-only topology, hostnames, IP plans, or certificate material are exposed.
- [x] Security-sensitive behavior is not changed.

## Operational Risk And Rollback

Risk is low. This only changes when the IPAM CI job installs dependencies and runs tests.

Rollback: revert this PR to restore the previous unconditional IPAM dependency install/test behavior.