### PR TITLE
Harden bootstrap token path and add guarded repo cleanup retention

### DIFF
--- a/.github/workflows/verify-tokenfile.yml
+++ b/.github/workflows/verify-tokenfile.yml
@@ -28,6 +28,10 @@ jobs:
         run: |
           chmod +x scripts/render_rke2_config.py || true
           chmod +x tests/verify_no_duplicate_tokenfile.sh || true
+          chmod +x tests/test_tokenfile_paths.sh || true
+          chmod +x tests/test_token_strict_policy.sh || true
+          chmod +x tests/test_token_yaml_key_normalization.sh || true
+          chmod +x tests/test_repo_cleanup_contract.sh || true
 
       - name: Validate example YAML files
         run: |
@@ -49,3 +53,10 @@ jobs:
       - name: Run duplicate-token-file verification
         run: |
           ./tests/verify_no_duplicate_tokenfile.sh
+
+      - name: Run token and cleanup contract tests
+        run: |
+          ./tests/test_tokenfile_paths.sh
+          ./tests/test_token_strict_policy.sh
+          ./tests/test_token_yaml_key_normalization.sh
+          ./tests/test_repo_cleanup_contract.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- No unreleased changes yet.
+- Bootstrap token handling now hard-cuts over to canonical protected host path `/etc/rancher/rke2/token.d/bootstrap.token` for `server`, `agent`, and `add-server` actions.
+- `tokenFile` manifest references across shipped node configs now point to `/etc/rancher/rke2/token.d/bootstrap.token`.
+- Legacy outputs-based bootstrap token artifact generation paths were removed from image/token helper flows.
+- Successful `server`, `agent`, and `add-server` completion now performs guarded repository cleanup for `/rke2-node-init`.
+
+### Added
+
+- Deferred post-success cleanup pipeline that retains operational artifacts before repo cleanup:
+  - Logs under `/var/log/rke2-node-init/<action>-<timestamp>/`
+  - SBOM/metadata/security evidence under `/var/lib/rke2-node-init/artifacts/<action>-<timestamp>/`
+- Cleanup contract test coverage via `tests/test_repo_cleanup_contract.sh`.
 
 ## [3.0.0] - 2026-06-24
 

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 # Utility helpers for project maintenance.
 #
 # Usage:
-#   make token TOKEN_IMAGE_NAME=<image-name> [TOKEN_SIZE=24]
+#   make token [TOKEN_SIZE=24]
 #
 # TOKEN_SIZE controls the number of random bytes (default: 12) used when
 # generating the base64 token. The resulting token is echoed to stdout and
-# persisted under outputs/<image-name>/<image-name>-bootstrap-token.txt.
+# persisted at /etc/rancher/rke2/token.d/bootstrap.token.
 
 export SHELL := /bin/bash
 export TOKEN_SIZE ?= 32
@@ -15,23 +15,17 @@ export BOOT_ISO_OUTPUT_DIR ?= configs/gitops/boot-isos
 export BOOT_ISO_MANIFEST ?= ${BOOT_ISO_OUTPUT_DIR}/manifest.tsv
 
 .PHONY: token sh kubeconfig boot-isos boot-isos-clean ipam-install ipam-run ipam-test ipam-import
-## Generate a reusable base64 token and persist it for later use.
+## Generate a reusable base64 token and persist it at canonical host path.
 token:
 	@set -euo pipefail; \
-		if [[ -z "${TOKEN_IMAGE_NAME}" ]]; then \
-			echo "ERROR: TOKEN_IMAGE_NAME is required (example: make token TOKEN_IMAGE_NAME=vmware-devlocal-image)"; \
-			exit 1; \
-		fi; \
-		if [[ "${TOKEN_IMAGE_NAME}" == */* ]]; then \
-			echo "ERROR: TOKEN_IMAGE_NAME must be a single folder name, not a path: ${TOKEN_IMAGE_NAME}"; \
-			exit 1; \
-		fi; \
-		TOKEN_OUTPUT_DIR="outputs/${TOKEN_IMAGE_NAME}"; \
-		TOKEN_FILE="${TOKEN_OUTPUT_DIR}/${TOKEN_IMAGE_NAME}-bootstrap-token.txt"; \
-		install -d -m 700 "${TOKEN_OUTPUT_DIR}"; \
+		TOKEN_FILE="/etc/rancher/rke2/token.d/bootstrap.token"; \
+		TOKEN_TMP="$${TMPDIR:-/tmp}/rke2-bootstrap-token.$$$$"; \
 		TOKEN="$$(openssl rand -base64 ${TOKEN_SIZE})"; \
-		printf '%s\n' "$${TOKEN}" | tee "${TOKEN_FILE}"; \
-		chmod 600 "${TOKEN_FILE}"; \
+		printf '%s\n' "$${TOKEN}" > "$${TOKEN_TMP}"; \
+		chmod 600 "$${TOKEN_TMP}"; \
+		sudo install -d -m 700 "$$(dirname "${TOKEN_FILE}")"; \
+		sudo install -m 600 "$${TOKEN_TMP}" "${TOKEN_FILE}"; \
+		rm -f "$${TOKEN_TMP}"; \
 		echo "     Token: $${TOKEN}"; \
 		echo "Token File: ${TOKEN_FILE}";
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Usage:
 #   make token [TOKEN_SIZE=24]
 #
-# TOKEN_SIZE controls the number of random bytes (default: 12) used when
+# TOKEN_SIZE controls the number of random bytes (default: 32) used when
 # generating the base64 token. The resulting token is echoed to stdout and
 # persisted at /etc/rancher/rke2/token.d/bootstrap.token.
 
@@ -19,7 +19,7 @@ export BOOT_ISO_MANIFEST ?= ${BOOT_ISO_OUTPUT_DIR}/manifest.tsv
 token:
 	@set -euo pipefail; \
 		TOKEN_FILE="/etc/rancher/rke2/token.d/bootstrap.token"; \
-		TOKEN_TMP="$${TMPDIR:-/tmp}/rke2-bootstrap-token.$$$$"; \
+		TOKEN_TMP="$$(mktemp "$${TMPDIR:-/tmp}/rke2-bootstrap-token.XXXXXX")"; \
 		TOKEN="$$(openssl rand -base64 ${TOKEN_SIZE})"; \
 		printf '%s\n' "$${TOKEN}" > "$${TOKEN_TMP}"; \
 		chmod 600 "$${TOKEN_TMP}"; \

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Utility helpers for project maintenance.
 #
 # Usage:
-#   make token [TOKEN_SIZE=24]
+#   make token [TOKEN_SIZE=32]
 #
 # TOKEN_SIZE controls the number of random bytes (default: 32) used when
 # generating the base64 token. The resulting token is echoed to stdout and

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 # Utility helpers for project maintenance.
 #
 # Usage:
-#   make token [TOKEN_SIZE=32]
+#   make token [TOKEN_SIZE=24]
 #
-# TOKEN_SIZE controls the number of random bytes (default: 32) used when
+# TOKEN_SIZE controls the number of random bytes (default: 12) used when
 # generating the base64 token. The resulting token is echoed to stdout and
 # persisted at /etc/rancher/rke2/token.d/bootstrap.token.
 
@@ -19,7 +19,7 @@ export BOOT_ISO_MANIFEST ?= ${BOOT_ISO_OUTPUT_DIR}/manifest.tsv
 token:
 	@set -euo pipefail; \
 		TOKEN_FILE="/etc/rancher/rke2/token.d/bootstrap.token"; \
-		TOKEN_TMP="$$(mktemp "$${TMPDIR:-/tmp}/rke2-bootstrap-token.XXXXXX")"; \
+		TOKEN_TMP="$${TMPDIR:-/tmp}/rke2-bootstrap-token.$$$$"; \
 		TOKEN="$$(openssl rand -base64 ${TOKEN_SIZE})"; \
 		printf '%s\n' "$${TOKEN}" > "$${TOKEN_TMP}"; \
 		chmod 600 "$${TOKEN_TMP}"; \

--- a/bin/rke2nodeinit-core.sh
+++ b/bin/rke2nodeinit-core.sh
@@ -197,6 +197,18 @@ BOOTSTRAP_TOKEN_FILE=""
 # Captures attempted token-file resolution candidates for diagnostics.
 TOKEN_FILE_RESOLUTION_ATTEMPTS=""
 
+# Canonical bootstrap token host path (hard cutover).
+CANONICAL_BOOTSTRAP_TOKEN_DIR="/etc/rancher/rke2/token.d"
+CANONICAL_BOOTSTRAP_TOKEN_FILE="${CANONICAL_BOOTSTRAP_TOKEN_DIR}/bootstrap.token"
+
+# Post-success repo cleanup and artifact retention defaults.
+CLEANUP_REPO_ON_SUCCESS="${CLEANUP_REPO_ON_SUCCESS:-1}"
+REPO_CLEANUP_ALLOW_PATH="/rke2-node-init"
+ARTIFACT_RETENTION_ROOT="${ARTIFACT_RETENTION_ROOT:-/var/lib/rke2-node-init/artifacts}"
+ARTIFACT_RETENTION_LOG_DIR="${ARTIFACT_RETENTION_LOG_DIR:-/var/log/rke2-node-init}"
+POST_SUCCESS_CLEANUP_ENABLED=0
+POST_SUCCESS_CLEANUP_ACTION=""
+
 # Track the CA file used when deriving full tokens so runs can archive it.
 AGENT_CA_CERT=""
 
@@ -4728,10 +4740,8 @@ resolve_boot_yaml_dir() {
 # ------------------------------------------------------------------------------
 # Function: resolve_token_file_path
 # Purpose : Resolve a token-file path to a readable absolute path. Relative
-#           paths are evaluated against CONFIG_FILE directory, then REPO_ROOT,
-#           then current working directory.
-#           Legacy token-file paths under /outputs/<name>-bootstrap-token.txt
-#           are also mapped to /outputs/<name>/<name>-bootstrap-token.txt.
+#           paths are evaluated only for diagnostics. Hard cutover requires the
+#           canonical protected host token file path.
 # Arguments:
 #   $1 - Raw token-file path
 # Returns :
@@ -4740,45 +4750,17 @@ resolve_boot_yaml_dir() {
 # ------------------------------------------------------------------------------
 resolve_token_file_path() {
   local raw_path="$1"
-  local cfg_dir=""
   local candidate=""
-  local resolved=""
-  local legacy_outputs_rel=""
-  local legacy_prefix=""
-  local legacy_name=""
+  local canonical="$CANONICAL_BOOTSTRAP_TOKEN_FILE"
   local -a candidates=()
   local -A seen=()
 
   TOKEN_FILE_RESOLUTION_ATTEMPTS=""
   [[ -n "$raw_path" ]] || return 1
 
-  if [[ "$raw_path" =~ (^|.*/)outputs/([^/]+)-bootstrap-token\.txt$ ]]; then
-    legacy_prefix="${BASH_REMATCH[1]}outputs"
-    legacy_name="${BASH_REMATCH[2]}"
-    legacy_outputs_rel="${legacy_prefix}/${legacy_name}/${legacy_name}-bootstrap-token.txt"
-  fi
-
-  if [[ "$raw_path" == /* ]]; then
-    candidates+=("$raw_path")
-    if [[ -n "$legacy_outputs_rel" ]]; then
-      candidates+=("$legacy_outputs_rel")
-    fi
-  else
-    if [[ -n "${CONFIG_FILE:-}" ]]; then
-      cfg_dir="$(dirname -- "$CONFIG_FILE")"
-      candidates+=("$cfg_dir/$raw_path")
-      if [[ -n "$legacy_outputs_rel" ]]; then
-        candidates+=("$cfg_dir/$legacy_outputs_rel")
-      fi
-    fi
-    candidates+=("$REPO_ROOT/$raw_path")
-    if [[ -n "$legacy_outputs_rel" ]]; then
-      candidates+=("$REPO_ROOT/$legacy_outputs_rel")
-    fi
-    candidates+=("$raw_path")
-    if [[ -n "$legacy_outputs_rel" ]]; then
-      candidates+=("$legacy_outputs_rel")
-    fi
+  candidates+=("$raw_path")
+  if [[ "$raw_path" != "$canonical" ]]; then
+    candidates+=("$canonical")
   fi
 
   for candidate in "${candidates[@]}"; do
@@ -4789,14 +4771,143 @@ resolve_token_file_path() {
     seen["$candidate"]=1
     TOKEN_FILE_RESOLUTION_ATTEMPTS+="${TOKEN_FILE_RESOLUTION_ATTEMPTS:+, }$candidate"
 
-    if [[ -f "$candidate" && -r "$candidate" ]]; then
-      resolved="$(cd -- "$(dirname -- "$candidate")" && pwd -P)/$(basename -- "$candidate")"
-      printf '%s\n' "$resolved"
+    if [[ "$candidate" == "$canonical" && -f "$candidate" && -r "$candidate" ]]; then
+      printf '%s\n' "$candidate"
       return 0
     fi
   done
 
   return 1
+}
+
+# ------------------------------------------------------------------------------
+# Function: write_token_to_canonical_file
+# Purpose : Persist a token value to the canonical protected host file.
+# Arguments:
+#   $1 - Token value
+# Returns :
+#   Prints canonical token path on success; non-zero on failure.
+# ------------------------------------------------------------------------------
+write_token_to_canonical_file() {
+  local token_value="${1:-}"
+  local tmp_file=""
+
+  [[ -n "$token_value" ]] || return 1
+  mkdir -p "$CANONICAL_BOOTSTRAP_TOKEN_DIR"
+  chmod 700 "$CANONICAL_BOOTSTRAP_TOKEN_DIR"
+
+  tmp_file="$(mktemp "$CANONICAL_BOOTSTRAP_TOKEN_DIR/.bootstrap.token.XXXXXX")"
+  printf '%s\n' "$token_value" > "$tmp_file"
+  chmod 600 "$tmp_file"
+  mv -f "$tmp_file" "$CANONICAL_BOOTSTRAP_TOKEN_FILE"
+  chmod 600 "$CANONICAL_BOOTSTRAP_TOKEN_FILE"
+  printf '%s\n' "$CANONICAL_BOOTSTRAP_TOKEN_FILE"
+  return 0
+}
+
+# ------------------------------------------------------------------------------
+# Function: schedule_post_success_cleanup
+# Purpose : Defer repo cleanup until prompt_reboot so failures still preserve
+#           scripts in-place.
+# Arguments:
+#   $1 - Action label (server|agent|add-server)
+# ------------------------------------------------------------------------------
+schedule_post_success_cleanup() {
+  local action_label="${1:-}"
+  POST_SUCCESS_CLEANUP_ENABLED=1
+  POST_SUCCESS_CLEANUP_ACTION="$action_label"
+}
+
+# ------------------------------------------------------------------------------
+# Function: retain_operational_artifacts
+# Purpose : Preserve logs/SBOM/security metadata outside repo before cleanup.
+# Arguments:
+#   $1 - Action label
+# Returns :
+#   0 on success, non-zero when retention fails.
+# ------------------------------------------------------------------------------
+retain_operational_artifacts() {
+  local action_label="${1:-node}"
+  local stamp=""
+  local action_artifact_dir=""
+  local action_log_dir=""
+  local rc=0
+
+  stamp="$(date +%Y%m%d-%H%M%S)"
+  action_artifact_dir="$ARTIFACT_RETENTION_ROOT/${action_label}-${stamp}"
+  action_log_dir="$ARTIFACT_RETENTION_LOG_DIR/${action_label}-${stamp}"
+
+  mkdir -p "$action_artifact_dir" "$action_log_dir" || return 1
+  chmod 750 "$ARTIFACT_RETENTION_ROOT" "$ARTIFACT_RETENTION_LOG_DIR" "$action_artifact_dir" "$action_log_dir" 2>/dev/null || true
+
+  if [[ -n "${LOG_FILE:-}" && -f "$LOG_FILE" ]]; then
+    if cp -f "$LOG_FILE" "$action_log_dir/"; then
+      chmod 640 "$action_log_dir/$(basename -- "$LOG_FILE")" 2>/dev/null || true
+    else
+      rc=1
+    fi
+  fi
+
+  if [[ -d "$SBOM_DIR" ]]; then
+    if ! cp -a "$SBOM_DIR" "$action_artifact_dir/"; then
+      rc=1
+    fi
+  fi
+
+  if [[ -d "$OUT_DIR" ]]; then
+    while IFS= read -r -d '' artifact; do
+      local rel="${artifact#${OUT_DIR}/}"
+      local target_dir="$action_artifact_dir/outputs/$(dirname -- "$rel")"
+      mkdir -p "$target_dir" || { rc=1; continue; }
+      cp -f "$artifact" "$target_dir/" || rc=1
+    done < <(find "$OUT_DIR" -maxdepth 4 -type f \( -name '*sbom*' -o -name '*manifest*' -o -name '*metadata*' -o -name '*scan*' -o -name '*.spdx.json' -o -name '*.inspect.json' \) -print0 2>/dev/null)
+  fi
+
+  [[ "$rc" -eq 0 ]]
+}
+
+# ------------------------------------------------------------------------------
+# Function: maybe_cleanup_repo_after_success
+# Purpose : Remove repo after successful bootstrap actions, preserving artifacts.
+# Arguments:
+#   $1 - Action label
+# ------------------------------------------------------------------------------
+maybe_cleanup_repo_after_success() {
+  local action_label="${1:-node}"
+  local repo_real=""
+
+  if [[ "${CLEANUP_REPO_ON_SUCCESS:-1}" != "1" ]]; then
+    return 0
+  fi
+
+  repo_real="$(cd -- "$REPO_ROOT" && pwd -P 2>/dev/null || true)"
+  if [[ -z "$repo_real" || "$repo_real" != "$REPO_CLEANUP_ALLOW_PATH" || "$repo_real" == "/" ]]; then
+    log_warn "Skipping repo cleanup: path is not allow-listed ($repo_real)"
+    return 0
+  fi
+
+  if ! retain_operational_artifacts "$action_label"; then
+    log_warn "Artifact retention failed; preserving repository at $repo_real for safety"
+    return 0
+  fi
+
+  log_info "Removing working repository after successful ${action_label} bootstrap: $repo_real"
+  rm -rf --one-file-system "$repo_real"
+}
+
+# ------------------------------------------------------------------------------
+# Function: execute_pending_post_success_cleanup
+# Purpose : Run deferred cleanup scheduled by successful bootstrap actions.
+# ------------------------------------------------------------------------------
+execute_pending_post_success_cleanup() {
+  if [[ "${POST_SUCCESS_CLEANUP_ENABLED:-0}" != "1" ]]; then
+    return 0
+  fi
+
+  local action_label="${POST_SUCCESS_CLEANUP_ACTION:-node}"
+  POST_SUCCESS_CLEANUP_ENABLED=0
+  POST_SUCCESS_CLEANUP_ACTION=""
+  maybe_cleanup_repo_after_success "$action_label"
 }
 
 # ------------------------------------------------------------------------------
@@ -9096,6 +9207,7 @@ prompt_reboot() {
   
   if (( AUTO_YES )); then
     log WARN "Auto-confirm enabled (-y). Rebooting now..."
+    execute_pending_post_success_cleanup
     sleep 2
     reboot
   else
@@ -9103,11 +9215,13 @@ prompt_reboot() {
     case "${_ans,,}" in
       y|yes)
         log WARN "Rebooting..."
+        execute_pending_post_success_cleanup
         sleep 2
         reboot
         ;;
       *)
         log INFO "Reboot deferred. Remember to reboot before installing RKE2."
+        execute_pending_post_success_cleanup
         ;;
     esac
   fi
@@ -9745,96 +9859,9 @@ action_image() {
   metrics_increment "success"
   metrics_increment "registry_trust_configured"
 
-  # Generate a custom-CA bootstrap token file in image outputs when custom CA exists.
-  if [[ -n "$CA_ROOT" || -n "$CA_INTCRT" ]]; then
-    local image_token=""
-    local image_name="${SPEC_NAME:-image}"
-    local image_output_dir="${RUN_OUT_DIR:-$OUT_DIR/$image_name}"
-    local image_token_file="${image_output_dir}/${image_name}-bootstrap-token.txt"
-    local token_alias_yaml_dir=""
-    local _alias_manifest=""
-    local _alias_token_file=""
-    local _alias_dir_name=""
-    local _alias_expected_name=""
-    local _created_targets=""
-    local -A _written_token_targets=()
-
-    if [[ -n "$CA_ROOT" && ! -f "$CA_ROOT" ]]; then
-      log_error "Custom CA root certificate path is not readable during image action: $CA_ROOT"
-      log_error "Refusing to continue because image bootstrap token generation requires a valid custom CA input."
-      exit 1
-    fi
-    if [[ -n "$CA_INTCRT" && ! -f "$CA_INTCRT" ]]; then
-      log_error "Custom CA intermediate certificate path is not readable during image action: $CA_INTCRT"
-      log_error "Refusing to continue because image bootstrap token generation requires a valid custom CA input."
-      exit 1
-    fi
-
-    CUSTOM_CA_ROOT_CRT="${CA_ROOT:-${CUSTOM_CA_ROOT_CRT:-}}"
-    CUSTOM_CA_ROOT_KEY="${CA_KEY:-${CUSTOM_CA_ROOT_KEY:-}}"
-    CUSTOM_CA_INT_CRT="${CA_INTCRT:-${CUSTOM_CA_INT_CRT:-}}"
-    CUSTOM_CA_INT_KEY="${CA_INTKEY:-${CUSTOM_CA_INT_KEY:-}}"
-
-    if ! image_token="$(generate_bootstrap_token)"; then
-      log_error "Custom CA bootstrap token generation failed during image action."
-      exit 1
-    fi
-
-    image_token="${image_token//$'\n'/}"
-    image_token="${image_token//$'\r'/}"
-    if [[ -z "$image_token" ]]; then
-      log_error "Custom CA bootstrap token generation returned empty output during image action."
-      exit 1
-    fi
-
-    mkdir -p "$(dirname "$image_token_file")"
-    printf '%s\n' "$image_token" > "$image_token_file"
-    chmod 600 "$image_token_file"
-    _written_token_targets["$image_token_file"]=1
-    log_info "Custom CA bootstrap token generated: $image_token_file"
-
-    if [[ -n "$boot_yaml_path_cfg" ]]; then
-      token_alias_yaml_dir="$(resolve_boot_yaml_dir "$boot_yaml_path_cfg")"
-    elif [[ -n "${BOOT_YAML_PATH:-}" ]]; then
-      token_alias_yaml_dir="$(resolve_boot_yaml_dir "$BOOT_YAML_PATH")"
-    fi
-
-    if [[ -n "$token_alias_yaml_dir" && -d "$token_alias_yaml_dir" ]]; then
-      while IFS= read -r _alias_manifest; do
-        _alias_token_file="$(yaml_spec_get "$_alias_manifest" tokenFile || true)"
-        [[ -n "$_alias_token_file" ]] || continue
-
-        if [[ "$_alias_token_file" != /rke2-node-init/outputs/*/*-bootstrap-token.txt ]]; then
-          log_warn "Skipping bootstrap token alias for $_alias_manifest; tokenFile must match /rke2-node-init/outputs/<image>/<image>-bootstrap-token.txt: $_alias_token_file"
-          continue
-        fi
-
-        _alias_dir_name="$(basename -- "$(dirname -- "$_alias_token_file")")"
-        _alias_expected_name="${_alias_dir_name}-bootstrap-token.txt"
-        if [[ "$(basename -- "$_alias_token_file")" != "$_alias_expected_name" ]]; then
-          log_warn "Skipping bootstrap token alias for $_alias_manifest; tokenFile filename must match containing image folder name ($_alias_expected_name): $_alias_token_file"
-          continue
-        fi
-
-        if [[ -n "${_written_token_targets["$_alias_token_file"]+x}" ]]; then
-          continue
-        fi
-
-        mkdir -p "$(dirname "$_alias_token_file")"
-        printf '%s\n' "$image_token" > "$_alias_token_file"
-        chmod 600 "$_alias_token_file" || true
-        _written_token_targets["$_alias_token_file"]=1
-        log_info "Created bootstrap token alias for $_alias_manifest: $_alias_token_file"
-      done < <(find "$token_alias_yaml_dir" -maxdepth 1 -type f \( -name '*.yaml' -o -name '*.yml' \) | sort)
-    fi
-
-    for _alias_token_file in "${!_written_token_targets[@]}"; do
-      _created_targets+="${_created_targets:+, }${_alias_token_file}"
-    done
-    log_info "Bootstrap token artifacts created: ${_created_targets}"
-  else
-    log_info "No customCA stanza detected; skipping custom CA bootstrap token generation."
-  fi
+  # Bootstrap tokens are no longer emitted into repository output paths.
+  # Runtime bootstrap now reads the canonical protected host token file.
+  log_info "Skipping outputs-based bootstrap token generation during image action."
 
   # Immediately persist a minimal RKE2 configuration for air‑gapped bootstraps.
   # RKE2 will automatically import images from /var/lib/rancher/rke2/agent/images
@@ -10944,6 +10971,22 @@ action_server() {
   # Phase 7: Token and RKE2 configuration
   report_progress "Writing RKE2 configuration" 7 8
   log_info "Validating/expanding provided token (if any)..."
+  if [[ -n "$TOKEN" ]]; then
+    local canonical_token_file=""
+    canonical_token_file="$(write_token_to_canonical_file "$TOKEN" || true)"
+    if [[ -z "$canonical_token_file" ]]; then
+      log_error "Failed to persist provided token to canonical path: $CANONICAL_BOOTSTRAP_TOKEN_FILE"
+      metrics_increment "total"
+      metrics_increment "failed"
+      exit 1
+    fi
+    TOKEN_FILE="$canonical_token_file"
+    TOKEN=""
+    log_info "Persisted provided token to canonical token-file path."
+  elif [[ -z "$TOKEN_FILE" ]]; then
+    TOKEN_FILE="$CANONICAL_BOOTSTRAP_TOKEN_FILE"
+  fi
+
   if [[ -n "$TOKEN_FILE" ]]; then
     local resolved_token_file=""
     resolved_token_file="$(resolve_token_file_path "$TOKEN_FILE" || true)"
@@ -10952,44 +10995,19 @@ action_server() {
       log_info "Token file provided and found; using token-file: $TOKEN_FILE"
       TOKEN=""
     else
-      if [[ "$via_boot_service" -eq 1 ]]; then
-        log_warn "Token file provided but unavailable during boot-service run: $TOKEN_FILE"
-        if [[ -n "${TOKEN_FILE_RESOLUTION_ATTEMPTS:-}" ]]; then
-          log_warn "Attempted token file paths: $TOKEN_FILE_RESOLUTION_ATTEMPTS"
-        fi
-        log_warn "Proceeding without token-file; generating a first-server bootstrap token for this run."
-        TOKEN_FILE=""
-      else
-        log_error "Token file provided but unavailable: $TOKEN_FILE"
-        if [[ -n "${TOKEN_FILE_RESOLUTION_ATTEMPTS:-}" ]]; then
-          log_error "Attempted token file paths: $TOKEN_FILE_RESOLUTION_ATTEMPTS"
-        fi
-        log_error "Remediation: provide a readable absolute path or a path relative to the manifest/repository root."
-        metrics_increment "total"
-        metrics_increment "failed"
-        exit 1
+      log_error "Token file provided but unavailable: $TOKEN_FILE"
+      if [[ -n "${TOKEN_FILE_RESOLUTION_ATTEMPTS:-}" ]]; then
+        log_error "Attempted token file paths: $TOKEN_FILE_RESOLUTION_ATTEMPTS"
       fi
-    fi
-  elif [[ -n "$TOKEN" ]]; then
-    local full_token
-    full_token="$(ensure_full_cluster_token "$TOKEN")"
-    if [[ -n "$full_token" ]]; then
-      if [[ "$full_token" != "$TOKEN" ]]; then
-        log_info "Expanded provided token to full format (custom CA hash included)."
-      fi
-      TOKEN="$full_token"
-    fi
-  else
-    TOKEN="$(generate_bootstrap_token)"
-    if [[ "$TOKEN" =~ ^K10[0-9a-fA-F]{64}::server: ]]; then
-      log_info "Using generated secure first-server token (custom CA fingerprint embedded)."
-    else
-      log_info "Using generated short first-server bootstrap token."
+      log_error "Remediation: ensure canonical token file exists and is readable at $CANONICAL_BOOTSTRAP_TOKEN_FILE."
+      metrics_increment "total"
+      metrics_increment "failed"
+      exit 1
     fi
   fi
   metrics_increment "total"
   metrics_increment "success"
-  metrics_increment "token_generated"
+  metrics_increment "token_configured"
 
   BOOTSTRAP_TOKEN_FILE="$TOKEN_FILE"
   log_info "Seeding custom cluster CA..."
@@ -11180,6 +11198,7 @@ action_server() {
     echo "[DRY-RUN] Server configuration validated. No changes made."
   fi
   echo
+  schedule_post_success_cleanup "server"
   prompt_reboot
 }
 
@@ -11442,6 +11461,21 @@ action_agent() {
   fi
 
   log_info "Validating/expanding provided token (if any)..."
+  if [[ -n "$TOKEN" ]]; then
+    local canonical_token_file=""
+    canonical_token_file="$(write_token_to_canonical_file "$TOKEN" || true)"
+    if [[ -z "$canonical_token_file" ]]; then
+      log_error "Failed to persist provided token to canonical path: $CANONICAL_BOOTSTRAP_TOKEN_FILE"
+      metrics_increment "failed"
+      exit 1
+    fi
+    TOKEN_FILE="$canonical_token_file"
+    TOKEN=""
+    log_info "Persisted provided token to canonical token-file path."
+  elif [[ -z "$TOKEN_FILE" ]]; then
+    TOKEN_FILE="$CANONICAL_BOOTSTRAP_TOKEN_FILE"
+  fi
+
   if [[ -n "$TOKEN_FILE" ]]; then
     local resolved_token_file=""
     resolved_token_file="$(resolve_token_file_path "$TOKEN_FILE" || true)"
@@ -11450,7 +11484,7 @@ action_agent() {
       if [[ -n "${TOKEN_FILE_RESOLUTION_ATTEMPTS:-}" ]]; then
         log_error "Attempted token file paths: $TOKEN_FILE_RESOLUTION_ATTEMPTS"
       fi
-      log_error "Remediation: provide a readable absolute path or a path relative to the manifest/repository root."
+      log_error "Remediation: ensure canonical token file exists and is readable at $CANONICAL_BOOTSTRAP_TOKEN_FILE."
       metrics_increment "failed"
       exit 1
     fi
@@ -11458,15 +11492,6 @@ action_agent() {
     TOKEN_FILE="$resolved_token_file"
     log_info "Token file provided and found; using token-file: $TOKEN_FILE"
     TOKEN=""
-  elif [[ -n "$TOKEN" ]]; then
-    local full_token=""
-    full_token="$(ensure_full_cluster_token "$TOKEN")"
-    if [[ -n "$full_token" ]]; then
-      if [[ "$full_token" != "$TOKEN" ]]; then
-        log_info "Expanded agent join token to full format (custom CA hash included)."
-      fi
-      TOKEN="$full_token"
-    fi
   fi
   metrics_increment "token_configured"
 
@@ -11622,6 +11647,7 @@ action_agent() {
     echo "[DRY-RUN] Agent configuration validated. No changes made."
   fi
   echo
+  schedule_post_success_cleanup "agent"
   prompt_reboot
 }
 
@@ -11901,6 +11927,21 @@ action_add_server() {
   [[ -z "$TLS_SANS" ]] && read -rp "Optional TLS SANs (CSV; hostnames/IPs) [blank=skip]: " TLS_SANS || true
 
   log_info "Validating/expanding provided token (if any)..."
+  if [[ -n "$TOKEN" ]]; then
+    local canonical_token_file=""
+    canonical_token_file="$(write_token_to_canonical_file "$TOKEN" || true)"
+    if [[ -z "$canonical_token_file" ]]; then
+      log_error "Failed to persist provided token to canonical path: $CANONICAL_BOOTSTRAP_TOKEN_FILE"
+      metrics_increment "failed"
+      exit 1
+    fi
+    TOKEN_FILE="$canonical_token_file"
+    TOKEN=""
+    log_info "Persisted provided token to canonical token-file path."
+  elif [[ -z "$TOKEN_FILE" ]]; then
+    TOKEN_FILE="$CANONICAL_BOOTSTRAP_TOKEN_FILE"
+  fi
+
   if [[ -n "$TOKEN_FILE" ]]; then
     local resolved_token_file=""
     resolved_token_file="$(resolve_token_file_path "$TOKEN_FILE" || true)"
@@ -11909,7 +11950,7 @@ action_add_server() {
       if [[ -n "${TOKEN_FILE_RESOLUTION_ATTEMPTS:-}" ]]; then
         log_error "Attempted token file paths: $TOKEN_FILE_RESOLUTION_ATTEMPTS"
       fi
-      log_error "Remediation: provide a readable absolute path or a path relative to the manifest/repository root."
+      log_error "Remediation: ensure canonical token file exists and is readable at $CANONICAL_BOOTSTRAP_TOKEN_FILE."
       metrics_increment "failed"
       exit 1
     fi
@@ -11917,15 +11958,6 @@ action_add_server() {
     TOKEN_FILE="$resolved_token_file"
     log_info "Token file provided and found; using token-file: $TOKEN_FILE"
     TOKEN=""
-  elif [[ -n "$TOKEN" ]]; then
-    local full_token=""
-    full_token="$(ensure_full_cluster_token "$TOKEN")"
-    if [[ -n "$full_token" ]]; then
-      if [[ "$full_token" != "$TOKEN" ]]; then
-        log_info "Expanded server join token to full format (custom CA hash included)."
-      fi
-      TOKEN="$full_token"
-    fi
   fi
 
   if [[ -n "${CUSTOM_CA_ROOT_CRT:-}" || -n "${CUSTOM_CA_INT_CRT:-}" ]]; then
@@ -12122,6 +12154,7 @@ action_add_server() {
     echo "[DRY-RUN] Add-server configuration validated. No changes made."
   fi
   echo
+  schedule_post_success_cleanup "add-server"
   prompt_reboot
 }
 

--- a/configs/cotpa-datacenter-lab/nodes/dc1domain-ctrl01.yaml
+++ b/configs/cotpa-datacenter-lab/nodes/dc1domain-ctrl01.yaml
@@ -35,7 +35,7 @@ spec:
       searchDomains: ["cantrelloffice.home", "cantrelloffice.com"]
   node-label:
   - "env=production"
-  tokenFile: /rke2-node-init/outputs/hyperv-cotpa-datacenter-lab-image-bootstrap-token.txt
+  tokenFile: /etc/rancher/rke2/token.d/bootstrap.token
   customCA:
     rootCrt: /rke2-node-init/configs/cotpa/certs/cocloud-ca.crt
     rootKey: /rke2-node-init/configs/cotpa/certs/cocloud-ca-key.pem

--- a/configs/cotpa-datacenter-lab/nodes/dc1domain-work01.yaml
+++ b/configs/cotpa-datacenter-lab/nodes/dc1domain-work01.yaml
@@ -36,7 +36,7 @@ spec:
   node-label:
   - "role=worker"
   - "env=production"
-  tokenFile: /rke2-node-init/outputs/hyperv-cotpa-datacenter-lab-image-bootstrap-token.txt
+  tokenFile: /etc/rancher/rke2/token.d/bootstrap.token
   customCA:
     rootCrt: /rke2-node-init/configs/cotpa/certs/cocloud-ca.crt
     rootKey: /rke2-node-init/configs/cotpa/certs/cocloud-ca-key.pem

--- a/configs/cotpa-datacenter-lab/nodes/dc1domain-work02.yaml
+++ b/configs/cotpa-datacenter-lab/nodes/dc1domain-work02.yaml
@@ -36,7 +36,7 @@ spec:
   node-label:
   - "role=worker"
   - "env=production"
-  tokenFile: /rke2-node-init/outputs/hyperv-cotpa-datacenter-lab-image-bootstrap-token.txt
+  tokenFile: /etc/rancher/rke2/token.d/bootstrap.token
   customCA:
     rootCrt: /rke2-node-init/configs/cotpa/certs/cocloud-ca.crt
     rootKey: /rke2-node-init/configs/cotpa/certs/cocloud-ca-key.pem

--- a/configs/cotpa-datacenter-lab/nodes/dc1manager-ctrl01.yaml
+++ b/configs/cotpa-datacenter-lab/nodes/dc1manager-ctrl01.yaml
@@ -35,7 +35,7 @@ spec:
       searchDomains: ["cantrelloffice.home", "cantrelloffice.com"]
   node-label:
   - "env=production"
-  tokenFile: /rke2-node-init/outputs/hyperv-cotpa-datacenter-lab-image-bootstrap-token.txt
+  tokenFile: /etc/rancher/rke2/token.d/bootstrap.token
   customCA:
     rootCrt: /rke2-node-init/configs/cotpa/certs/cocloud-ca.crt
     rootKey: /rke2-node-init/configs/cotpa/certs/cocloud-ca-key.pem

--- a/configs/cotpa-datacenter-lab/nodes/dc1manager-work01.yaml
+++ b/configs/cotpa-datacenter-lab/nodes/dc1manager-work01.yaml
@@ -36,7 +36,7 @@ spec:
   node-label:
   - "role=worker"
   - "env=production"
-  tokenFile: /rke2-node-init/outputs/hyperv-cotpa-datacenter-lab-image-bootstrap-token.txt
+  tokenFile: /etc/rancher/rke2/token.d/bootstrap.token
   customCA:
     rootCrt: /rke2-node-init/configs/cotpa/certs/cocloud-ca.crt
     rootKey: /rke2-node-init/configs/cotpa/certs/cocloud-ca-key.pem

--- a/configs/cotpa-datacenter-lab/nodes/dc1manager-work02.yaml
+++ b/configs/cotpa-datacenter-lab/nodes/dc1manager-work02.yaml
@@ -36,7 +36,7 @@ spec:
   node-label:
   - "role=worker"
   - "env=production"
-  tokenFile: /rke2-node-init/outputs/hyperv-cotpa-datacenter-lab-image-bootstrap-token.txt
+  tokenFile: /etc/rancher/rke2/token.d/bootstrap.token
   customCA:
     rootCrt: /rke2-node-init/configs/cotpa/certs/cocloud-ca.crt
     rootKey: /rke2-node-init/configs/cotpa/certs/cocloud-ca-key.pem

--- a/configs/cotpa-datacenter-lab/nodes/dc2domain-ctrl01.yaml
+++ b/configs/cotpa-datacenter-lab/nodes/dc2domain-ctrl01.yaml
@@ -35,7 +35,7 @@ spec:
       searchDomains: ["cantrelloffice.home", "cantrelloffice.com"]
   node-label:
   - "env=production"
-  tokenFile: /rke2-node-init/outputs/hyperv-cotpa-datacenter-lab-image-bootstrap-token.txt
+  tokenFile: /etc/rancher/rke2/token.d/bootstrap.token
   customCA:
     rootCrt: /rke2-node-init/configs/cotpa/certs/cocloud-ca.crt
     rootKey: /rke2-node-init/configs/cotpa/certs/cocloud-ca-key.pem

--- a/configs/cotpa-datacenter-lab/nodes/dc2domain-work01.yaml
+++ b/configs/cotpa-datacenter-lab/nodes/dc2domain-work01.yaml
@@ -36,7 +36,7 @@ spec:
   node-label:
   - "role=worker"
   - "env=production"
-  tokenFile: /rke2-node-init/outputs/hyperv-cotpa-datacenter-lab-image-bootstrap-token.txt
+  tokenFile: /etc/rancher/rke2/token.d/bootstrap.token
   customCA:
     rootCrt: /rke2-node-init/configs/cotpa/certs/cocloud-ca.crt
     rootKey: /rke2-node-init/configs/cotpa/certs/cocloud-ca-key.pem

--- a/configs/cotpa-datacenter-lab/nodes/dc2domain-work02.yaml
+++ b/configs/cotpa-datacenter-lab/nodes/dc2domain-work02.yaml
@@ -36,7 +36,7 @@ spec:
   node-label:
   - "role=worker"
   - "env=production"
-  tokenFile: /rke2-node-init/outputs/hyperv-cotpa-datacenter-lab-image-bootstrap-token.txt
+  tokenFile: /etc/rancher/rke2/token.d/bootstrap.token
   customCA:
     rootCrt: /rke2-node-init/configs/cotpa/certs/cocloud-ca.crt
     rootKey: /rke2-node-init/configs/cotpa/certs/cocloud-ca-key.pem

--- a/configs/cotpa-datacenter-lab/nodes/dc3domain-ctrl01.yaml
+++ b/configs/cotpa-datacenter-lab/nodes/dc3domain-ctrl01.yaml
@@ -35,7 +35,7 @@ spec:
       searchDomains: ["cantrelloffice.home", "cantrelloffice.com"]
   node-label:
   - "env=production"
-  tokenFile: /rke2-node-init/outputs/hyperv-cotpa-datacenter-lab-image-bootstrap-token.txt
+  tokenFile: /etc/rancher/rke2/token.d/bootstrap.token
   customCA:
     rootCrt: /rke2-node-init/configs/cotpa/certs/cocloud-ca.crt
     rootKey: /rke2-node-init/configs/cotpa/certs/cocloud-ca-key.pem

--- a/configs/cotpa-datacenter-lab/nodes/dc3domain-work01.yaml
+++ b/configs/cotpa-datacenter-lab/nodes/dc3domain-work01.yaml
@@ -36,7 +36,7 @@ spec:
   node-label:
   - "role=worker"
   - "env=production"
-  tokenFile: /rke2-node-init/outputs/hyperv-cotpa-datacenter-lab-image-bootstrap-token.txt
+  tokenFile: /etc/rancher/rke2/token.d/bootstrap.token
   customCA:
     rootCrt: /rke2-node-init/configs/cotpa/certs/cocloud-ca.crt
     rootKey: /rke2-node-init/configs/cotpa/certs/cocloud-ca-key.pem

--- a/configs/cotpa-datacenter-lab/nodes/dc3domain-work02.yaml
+++ b/configs/cotpa-datacenter-lab/nodes/dc3domain-work02.yaml
@@ -36,7 +36,7 @@ spec:
   node-label:
   - "role=worker"
   - "env=production"
-  tokenFile: /rke2-node-init/outputs/hyperv-cotpa-datacenter-lab-image-bootstrap-token.txt
+  tokenFile: /etc/rancher/rke2/token.d/bootstrap.token
   customCA:
     rootCrt: /rke2-node-init/configs/cotpa/certs/cocloud-ca.crt
     rootKey: /rke2-node-init/configs/cotpa/certs/cocloud-ca-key.pem

--- a/configs/cotpa-single-nodes/nodes/dc1domain.yaml
+++ b/configs/cotpa-single-nodes/nodes/dc1domain.yaml
@@ -53,7 +53,7 @@ spec:
       dns:
       searchDomains: ["cantrelloffice.cloud", "cantrell.cloud"]
 
-  tokenFile: /rke2-node-init/outputs/image-hyperv-v1.35.5+rke2r2-singlenode/image-hyperv-v1.35.5+rke2r2-singlenode-bootstrap-token.txt
+  tokenFile: /etc/rancher/rke2/token.d/bootstrap.token
   customCA:
     rootCrt: /rke2-node-init/configs/cotpa/certs/cocloud-ca.crt
     rootKey: /rke2-node-init/configs/cotpa/certs/cocloud-ca-key.pem

--- a/configs/cotpa-single-nodes/nodes/dc1manager.yaml
+++ b/configs/cotpa-single-nodes/nodes/dc1manager.yaml
@@ -53,7 +53,7 @@ spec:
       dns:
       searchDomains: ["cantrelloffice.cloud", "cantrell.cloud"]
 
-  tokenFile: /rke2-node-init/outputs/image-hyperv-v1.35.5+rke2r2-singlenode/image-hyperv-v1.35.5+rke2r2-singlenode-bootstrap-token.txt
+  tokenFile: /etc/rancher/rke2/token.d/bootstrap.token
   customCA:
     rootCrt: /rke2-node-init/configs/cotpa/certs/cocloud-ca.crt
     rootKey: /rke2-node-init/configs/cotpa/certs/cocloud-ca-key.pem

--- a/configs/cotpa-single-nodes/nodes/dc2domain.yaml
+++ b/configs/cotpa-single-nodes/nodes/dc2domain.yaml
@@ -53,7 +53,7 @@ spec:
       dns:
       searchDomains: ["cantrelloffice.cloud", "cantrell.cloud"]
 
-  tokenFile: /rke2-node-init/outputs/image-hyperv-v1.35.5+rke2r2-singlenode/image-hyperv-v1.35.5+rke2r2-singlenode-bootstrap-token.txt
+  tokenFile: /etc/rancher/rke2/token.d/bootstrap.token
   customCA:
     rootCrt: /rke2-node-init/configs/cotpa/certs/cocloud-ca.crt
     rootKey: /rke2-node-init/configs/cotpa/certs/cocloud-ca-key.pem

--- a/configs/cotpa-single-nodes/nodes/dc3domain.yaml
+++ b/configs/cotpa-single-nodes/nodes/dc3domain.yaml
@@ -53,7 +53,7 @@ spec:
       dns:
       searchDomains: ["cantrelloffice.cloud", "cantrell.cloud"]
 
-  tokenFile: /rke2-node-init/outputs/image-hyperv-v1.35.5+rke2r2-singlenode/image-hyperv-v1.35.5+rke2r2-singlenode-bootstrap-token.txt
+  tokenFile: /etc/rancher/rke2/token.d/bootstrap.token
   customCA:
     rootCrt: /rke2-node-init/configs/cotpa/certs/cocloud-ca.crt
     rootKey: /rke2-node-init/configs/cotpa/certs/cocloud-ca-key.pem

--- a/configs/cotpa/archive/cotpa-ctrl01.yaml
+++ b/configs/cotpa/archive/cotpa-ctrl01.yaml
@@ -50,7 +50,7 @@ spec:
   enable-servicelb: "false"
   kube-apiserver-arg:
     - "audit-log-maxage=15"
-  tokenFile: /rke2-node-init/outputs/cotpa-ca-bootstrap-token.txt
+  tokenFile: /etc/rancher/rke2/token.d/bootstrap.token
   disable:
   - rke2-ingress-nginx
   customCA:

--- a/configs/cotpa/archive/cotpa-ctrl02.yaml
+++ b/configs/cotpa/archive/cotpa-ctrl02.yaml
@@ -51,7 +51,7 @@ spec:
   kube-apiserver-arg:
     - "audit-log-maxage=15"
   serverURL: https://172.16.15.101:9345
-  tokenFile: /rke2-node-init/outputs/cotpa-ca-bootstrap-token.txt
+  tokenFile: /etc/rancher/rke2/token.d/bootstrap.token
   disable:
   - rke2-ingress-nginx
   customCA:

--- a/configs/cotpa/archive/cotpa-work01.yaml
+++ b/configs/cotpa/archive/cotpa-work01.yaml
@@ -35,7 +35,7 @@ spec:
       dns: 
       searchDomains: 
   serverURL: https://172.16.15.101:9345
-  tokenFile: /rke2-node-init/outputs/cotpa-ca-bootstrap-token.txt
+  tokenFile: /etc/rancher/rke2/token.d/bootstrap.token
   node-label:
   - "role=worker"
   - "env=development"

--- a/configs/cotpa/cotpa-k8admin.yaml
+++ b/configs/cotpa/cotpa-k8admin.yaml
@@ -46,7 +46,7 @@ spec:
   enable-servicelb: "false"
   kube-apiserver-arg:
     - "audit-log-maxage=15"
-  tokenFile: /rke2-node-init/outputs/cotpa-k8admin-ca-bootstrap-token.txt
+  tokenFile: /etc/rancher/rke2/token.d/bootstrap.token
   disable:
   - rke2-ingress-nginx
   customCA:

--- a/configs/cotpa/nodes/cotpakube01.yaml
+++ b/configs/cotpa/nodes/cotpakube01.yaml
@@ -48,7 +48,7 @@ spec:
   enable-servicelb: "false"
   kube-apiserver-arg:
     - "audit-log-maxage=15"
-  tokenFile: /rke2-node-init/outputs/cotpa-hyperv-v1.36.0+rke2r1-image-bootstrap-token.txt
+  tokenFile: /etc/rancher/rke2/token.d/bootstrap.token
   disable:
   - rke2-ingress-nginx
   customCA:

--- a/configs/cotpa/nodes/cotpakube02.yaml
+++ b/configs/cotpa/nodes/cotpakube02.yaml
@@ -49,7 +49,7 @@ spec:
   kube-apiserver-arg:
     - "audit-log-maxage=15"
   serverURL: https://172.16.15.101:9345
-  tokenFile: /rke2-node-init/outputs/cotpa-hyperv-v1.36.0+rke2r1-image-bootstrap-token.txt
+  tokenFile: /etc/rancher/rke2/token.d/bootstrap.token
   disable:
   - rke2-ingress-nginx
   customCA:

--- a/configs/cotpa/nodes/cotpakube03.yaml
+++ b/configs/cotpa/nodes/cotpakube03.yaml
@@ -49,7 +49,7 @@ spec:
   kube-apiserver-arg:
     - "audit-log-maxage=15"
   serverURL: https://172.16.15.101:9345
-  tokenFile: /rke2-node-init/outputs/cotpa-hyperv-v1.36.0+rke2r1-image-bootstrap-token.txt
+  tokenFile: /etc/rancher/rke2/token.d/bootstrap.token
   disable:
   - rke2-ingress-nginx
   customCA:

--- a/configs/dc1rkedev-cluster/nodes/dc1manager-ctrl01.yaml
+++ b/configs/dc1rkedev-cluster/nodes/dc1manager-ctrl01.yaml
@@ -21,7 +21,7 @@ spec:
       searchDomains: ["k8.cantrellcloud.net", "cantrellcloud.net", "cantrelloffice.cloud", "cantrell.cloud"]
   node-label:
   - "env=production"
-  tokenFile: /rke2-node-init/outputs/hyperv-dc1rkedev-cluster-image-bootstrap-token.txt
+  tokenFile: /etc/rancher/rke2/token.d/bootstrap.token
   customCA:
     rootCrt: /rke2-node-init/configs/dc1rkedev-cluster/certs/cocloud-ca.crt
     rootKey: /rke2-node-init/configs/dc1rkedev-cluster/certs/cocloud-ca-key.pem

--- a/configs/dc1rkedev-cluster/nodes/dc1manager-work01.yaml
+++ b/configs/dc1rkedev-cluster/nodes/dc1manager-work01.yaml
@@ -22,7 +22,7 @@ spec:
   node-label:
   - "role=worker"
   - "env=production"
-  tokenFile: /rke2-node-init/outputs/hyperv-dc1rkedev-cluster-image-bootstrap-token.txt
+  tokenFile: /etc/rancher/rke2/token.d/bootstrap.token
   customCA:
     rootCrt: /rke2-node-init/configs/dc1rkedev-cluster/certs/cocloud-ca.crt
     rootKey: /rke2-node-init/configs/dc1rkedev-cluster/certs/cocloud-ca-key.pem

--- a/configs/dc1rkedev-cluster/nodes/dc1manager-work02.yaml
+++ b/configs/dc1rkedev-cluster/nodes/dc1manager-work02.yaml
@@ -22,7 +22,7 @@ spec:
   node-label:
   - "role=worker"
   - "env=production"
-  tokenFile: /rke2-node-init/outputs/hyperv-dc1rkedev-cluster-image-bootstrap-token.txt
+  tokenFile: /etc/rancher/rke2/token.d/bootstrap.token
   customCA:
     rootCrt: /rke2-node-init/configs/dc1rkedev-cluster/certs/cocloud-ca.crt
     rootKey: /rke2-node-init/configs/dc1rkedev-cluster/certs/cocloud-ca-key.pem

--- a/configs/dc1rkedev-cluster/nodes/dc1manager-work03.yaml
+++ b/configs/dc1rkedev-cluster/nodes/dc1manager-work03.yaml
@@ -22,7 +22,7 @@ spec:
   node-label:
   - "role=worker"
   - "env=production"
-  tokenFile: /rke2-node-init/outputs/hyperv-dc1rkedev-cluster-image-bootstrap-token.txt
+  tokenFile: /etc/rancher/rke2/token.d/bootstrap.token
   customCA:
     rootCrt: /rke2-node-init/configs/dc1rkedev-cluster/certs/cocloud-ca.crt
     rootKey: /rke2-node-init/configs/dc1rkedev-cluster/certs/cocloud-ca-key.pem

--- a/configs/rkedomain-cluster/nodes/rkedomain-ctrl01.yaml
+++ b/configs/rkedomain-cluster/nodes/rkedomain-ctrl01.yaml
@@ -22,7 +22,7 @@ spec:
   node-label:
   - "env=production"
 
-  tokenFile: /rke2-node-init/outputs/image-hyperv-rkedomain-v1.35.6+rke2r1-bootstrap-token.txt
+  tokenFile: /etc/rancher/rke2/token.d/bootstrap.token
   customCA:
     rootCrt: /rke2-node-init/configs/rkedomain-cluster/certs/cocloud-ca.crt
     rootKey: /rke2-node-init/configs/rkedomain-cluster/certs/cocloud-ca-key.pem

--- a/configs/rkedomain-cluster/nodes/rkedomain-work01.yaml
+++ b/configs/rkedomain-cluster/nodes/rkedomain-work01.yaml
@@ -22,7 +22,7 @@ spec:
   node-label:
   - "role=worker"
   - "env=production"
-  tokenFile: /rke2-node-init/outputs/image-hyperv-rkedomain-v1.35.6+rke2r1-bootstrap-token.txt
+  tokenFile: /etc/rancher/rke2/token.d/bootstrap.token
   customCA:
     rootCrt: /rke2-node-init/configs/rkedomain-cluster/certs/cocloud-ca.crt
     rootKey: /rke2-node-init/configs/rkedomain-cluster/certs/cocloud-ca-key.pem

--- a/configs/rkedomain-cluster/nodes/rkedomain-work02.yaml
+++ b/configs/rkedomain-cluster/nodes/rkedomain-work02.yaml
@@ -22,7 +22,7 @@ spec:
   node-label:
   - "role=worker"
   - "env=production"
-  tokenFile: /rke2-node-init/outputs/image-hyperv-rkedomain-v1.35.6+rke2r1-bootstrap-token.txt
+  tokenFile: /etc/rancher/rke2/token.d/bootstrap.token
   customCA:
     rootCrt: /rke2-node-init/configs/rkedomain-cluster/certs/cocloud-ca.crt
     rootKey: /rke2-node-init/configs/rkedomain-cluster/certs/cocloud-ca-key.pem

--- a/configs/rkedomain-cluster/nodes/rkedomain-work03.yaml
+++ b/configs/rkedomain-cluster/nodes/rkedomain-work03.yaml
@@ -22,7 +22,7 @@ spec:
   node-label:
   - "role=worker"
   - "env=production"
-  tokenFile: /rke2-node-init/outputs/image-hyperv-rkedomain-v1.35.6+rke2r1-bootstrap-token.txt
+  tokenFile: /etc/rancher/rke2/token.d/bootstrap.token
   customCA:
     rootCrt: /rke2-node-init/configs/rkedomain-cluster/certs/cocloud-ca.crt
     rootKey: /rke2-node-init/configs/rkedomain-cluster/certs/cocloud-ca-key.pem

--- a/docs/OPERATIONAL-RUNBOOK.md
+++ b/docs/OPERATIONAL-RUNBOOK.md
@@ -81,10 +81,16 @@ sudo ./bin/rke2nodeinit.sh -f configs/preprod/nodes/dc1manager-work01.yaml agent
 ```
 
 Token policy for node provisioning:
-- Use `spec.tokenFile` (or `spec.token-file`) with canonical paths under `/rke2-node-init/outputs/<image>/<image>-bootstrap-token.txt` when using generated token artifacts.
-- If a token file path is provided but unreadable/unresolvable, `server`, `add-server`, and `agent` all fail fast with remediation output.
-- `server` only generates a bootstrap token when neither `token` nor `token-file` is supplied.
-- `add-server` and `agent` are join workflows and therefore require operator-provided token material.
+- Use `spec.tokenFile` (or `spec.token-file`) with the canonical protected host path `/etc/rancher/rke2/token.d/bootstrap.token`.
+- `server`, `agent`, and `add-server` now fail fast when the canonical token file is missing or unreadable.
+
+Post-bootstrap cleanup and artifact retention:
+- After successful `server`, `agent`, or `add-server` completion, the runtime working repository at `/rke2-node-init` is removed.
+- Cleanup is allow-listed and only executes for the expected path to prevent unintended deletions.
+- Operational evidence is retained before cleanup:
+  - Logs: `/var/log/rke2-node-init/<action>-<timestamp>/`
+  - SBOM and metadata artifacts: `/var/lib/rke2-node-init/artifacts/<action>-<timestamp>/`
+- If artifact retention fails, repo cleanup is skipped for safety.
 
 ## Phase 6: Verification
 
@@ -97,6 +103,8 @@ Check:
 - staged artifacts
 - service state
 - token file and custom CA references
+- retained logs under `/var/log/rke2-node-init/`
+- retained SBOM/metadata under `/var/lib/rke2-node-init/artifacts/`
 
 ## Phase 7: Hardening
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -104,12 +104,23 @@ Checks:
 
 ```bash
 grep -R "tokenFile:" configs/preprod configs/cotpa configs/cotpa-single-nodes
-ls -la outputs
+ls -la /etc/rancher/rke2/token.d
 ```
 
 Fix:
-- confirm token path points to `/rke2-node-init/outputs/...`
-- regenerate bootstrap token if needed
+- confirm token path points to `/etc/rancher/rke2/token.d/bootstrap.token`
+- confirm token file is readable and mode `0600`
+
+Artifact retention checks after successful bootstrap cleanup:
+
+```bash
+ls -la /var/log/rke2-node-init
+ls -la /var/lib/rke2-node-init/artifacts
+```
+
+Fix:
+- if directories are missing, review action logs and rerun with retention defaults
+- ensure `/var/log` and `/var/lib` have available space and writable permissions during bootstrap
 
 ### 6) Registry push failures
 

--- a/scripts/certs-auto.sh
+++ b/scripts/certs-auto.sh
@@ -136,9 +136,9 @@ if [[ "${GENERATE_TOKEN}" == "true" || "${GENERATE_TOKEN}" == "1" ]]; then
   echo "${FULL_TOKEN}" > "${TOKEN_TMP}"
   chmod 600 "${TOKEN_TMP}"
   sudo install -d -m 700 "$(dirname "${TOKEN_FILE}")"
-  sudo install -m 600 "${TOKEN_TMP}" "${TOKEN_FILE}" || true
+  sudo install -m 600 "${TOKEN_TMP}" "${TOKEN_FILE}"
   echo "Staging token to ${STAGE_DIR}/bootstrap.token"
-  sudo install -m 600 "${TOKEN_TMP}" "${STAGE_DIR}/bootstrap.token" || true
+  sudo install -m 600 "${TOKEN_TMP}" "${STAGE_DIR}/bootstrap.token"
   rm -f "${TOKEN_TMP}"
   echo "certs-auto completed. Root CA: ${ROOT_CERT_PATH}, Sub CA: ${SUB_CERT_PATH}, Token: ${TOKEN_FILE}"
 else

--- a/scripts/certs-auto.sh
+++ b/scripts/certs-auto.sh
@@ -12,9 +12,7 @@ TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
 ROOT_OUT="${OUTDIR}/root-${TIMESTAMP}"
 SUB_OUT="${OUTDIR}/subca-${TIMESTAMP}"
 STAGE_DIR="${STAGE_DIR:-/opt/rke2/stage/certs}"
-TOKEN_IMAGE_NAME="${TOKEN_IMAGE_NAME:-}"
-TOKEN_DIR=""
-TOKEN_FILE=""
+TOKEN_FILE="${TOKEN_FILE:-/etc/rancher/rke2/token.d/bootstrap.token}"
 GENERATE_TOKEN="${GENERATE_TOKEN:-true}"
 
 ROOT_CN="${ROOT_CN:-Offline Root CA}"
@@ -25,20 +23,7 @@ SUB_ENCRYPT="${SUB_ENCRYPT:-false}"
 SUB_PASSFILE="${SUB_PASSFILE:-}"
 SUB_PATHLEN="${SUB_PATHLEN:-1}"
 
-if [[ "${GENERATE_TOKEN}" == "true" || "${GENERATE_TOKEN}" == "1" ]]; then
-  if [[ -z "${TOKEN_IMAGE_NAME}" ]]; then
-    echo "ERROR: TOKEN_IMAGE_NAME is required when GENERATE_TOKEN=true (example: TOKEN_IMAGE_NAME=vmware-devlocal-image)" >&2
-    exit 1
-  fi
-  if [[ "${TOKEN_IMAGE_NAME}" == */* ]]; then
-    echo "ERROR: TOKEN_IMAGE_NAME must be a single folder name, not a path: ${TOKEN_IMAGE_NAME}" >&2
-    exit 1
-  fi
-  TOKEN_DIR="outputs/${TOKEN_IMAGE_NAME}"
-  TOKEN_FILE="${TOKEN_DIR}/${TOKEN_IMAGE_NAME}-bootstrap-token.txt"
-fi
-
-echo "certs-auto: OUTDIR=${OUTDIR} STAGE_DIR=${STAGE_DIR} TOKEN_IMAGE_NAME=${TOKEN_IMAGE_NAME:-<unset>}"
+echo "certs-auto: OUTDIR=${OUTDIR} STAGE_DIR=${STAGE_DIR} TOKEN_FILE=${TOKEN_FILE}"
 
 # Helper: ensure directory exists and is owned by current user; if not, use sudo
 ensure_dir() {
@@ -53,11 +38,6 @@ ensure_dir() {
 
 ensure_dir "${ROOT_OUT}"
 ensure_dir "${SUB_OUT}"
-
-# Ensure token dir only when token generation is enabled
-if [[ "${GENERATE_TOKEN}" == "true" || "${GENERATE_TOKEN}" == "1" ]]; then
-  ensure_dir "${TOKEN_DIR}"
-fi
 
 # Generate or use provided root passphrase
 if [[ -z "${ROOT_PASS}" ]]; then
@@ -144,6 +124,7 @@ fi
 
 # Compute ca_hash from subordinate cert (DER -> sha256)
 if [[ "${GENERATE_TOKEN}" == "true" || "${GENERATE_TOKEN}" == "1" ]]; then
+  TOKEN_TMP="$(mktemp)"
   CA_HASH="$(openssl x509 -outform der -in "${SUB_CERT_PATH}" 2>/dev/null | sha256sum 2>/dev/null | awk '{print $1}' || true)"
   if [[ -z "${CA_HASH}" ]]; then
     echo "WARNING: failed to compute CA_HASH from ${SUB_CERT_PATH}; falling back to simple token" >&2
@@ -152,13 +133,15 @@ if [[ "${GENERATE_TOKEN}" == "true" || "${GENERATE_TOKEN}" == "1" ]]; then
     FULL_TOKEN="K10${CA_HASH}::server:${PASSHEX}"
   fi
 
-  echo "${FULL_TOKEN}" > "${TOKEN_FILE}"
-  chmod 600 "${TOKEN_FILE}"
+  echo "${FULL_TOKEN}" > "${TOKEN_TMP}"
+  chmod 600 "${TOKEN_TMP}"
+  sudo install -d -m 700 "$(dirname "${TOKEN_FILE}")"
+  sudo install -m 600 "${TOKEN_TMP}" "${TOKEN_FILE}" || true
   echo "Staging token to ${STAGE_DIR}/bootstrap.token"
-  sudo install -m 600 "${TOKEN_FILE}" "${STAGE_DIR}/bootstrap.token" || true
+  sudo install -m 600 "${TOKEN_TMP}" "${STAGE_DIR}/bootstrap.token" || true
+  rm -f "${TOKEN_TMP}"
   echo "certs-auto completed. Root CA: ${ROOT_CERT_PATH}, Sub CA: ${SUB_CERT_PATH}, Token: ${TOKEN_FILE}"
 else
-  TOKEN_FILE=""
   echo "GENERATE_TOKEN is disabled; skipping token creation and token staging"
   echo "certs-auto completed. Root CA: ${ROOT_CERT_PATH}, Sub CA: ${SUB_CERT_PATH}, Token: <skipped>"
 fi

--- a/tests/test_repo_cleanup_contract.sh
+++ b/tests/test_repo_cleanup_contract.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/.." && pwd -P)"
+script="$root/bin/rke2nodeinit-core.sh"
+
+if [[ ! -f "$script" ]]; then
+  echo "Script not found: $script" >&2
+  exit 2
+fi
+
+if ! grep -Fq 'REPO_CLEANUP_ALLOW_PATH="/rke2-node-init"' "$script"; then
+  echo "ERROR: Repo cleanup allow-list path is missing or changed." >&2
+  exit 1
+fi
+
+if ! grep -Fq 'ARTIFACT_RETENTION_ROOT="${ARTIFACT_RETENTION_ROOT:-/var/lib/rke2-node-init/artifacts}"' "$script"; then
+  echo "ERROR: Artifact retention root default is missing." >&2
+  exit 1
+fi
+
+if ! grep -Fq 'ARTIFACT_RETENTION_LOG_DIR="${ARTIFACT_RETENTION_LOG_DIR:-/var/log/rke2-node-init}"' "$script"; then
+  echo "ERROR: Artifact retention log directory default is missing." >&2
+  exit 1
+fi
+
+if ! grep -Fq 'retain_operational_artifacts()' "$script"; then
+  echo "ERROR: Artifact retention function is missing." >&2
+  exit 1
+fi
+
+if ! grep -Fq 'if [[ -d "$SBOM_DIR" ]]; then' "$script"; then
+  echo "ERROR: SBOM retention copy logic is missing." >&2
+  exit 1
+fi
+
+if ! grep -Fq 'if [[ -z "$repo_real" || "$repo_real" != "$REPO_CLEANUP_ALLOW_PATH" || "$repo_real" == "/" ]]; then' "$script"; then
+  echo "ERROR: Repo cleanup path safety guard is missing." >&2
+  exit 1
+fi
+
+if ! grep -Fq 'rm -rf --one-file-system "$repo_real"' "$script"; then
+  echo "ERROR: Guarded repo cleanup delete operation is missing." >&2
+  exit 1
+fi
+
+schedule_calls="$(grep -F -c 'schedule_post_success_cleanup "' "$script" || true)"
+if [[ "$schedule_calls" -lt 3 ]]; then
+  echo "ERROR: Expected cleanup scheduling for server, agent, and add-server." >&2
+  exit 1
+fi
+
+execute_calls="$(grep -F -c 'execute_pending_post_success_cleanup' "$script" || true)"
+if [[ "$execute_calls" -lt 3 ]]; then
+  echo "ERROR: Expected deferred cleanup execution in reboot prompt paths." >&2
+  exit 1
+fi
+
+echo "Repo cleanup contract checks passed."

--- a/tests/test_token_strict_policy.sh
+++ b/tests/test_token_strict_policy.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 root="$(cd "$(dirname "$0")/.." && pwd -P)"
-script="$root/bin/rke2nodeinit.sh"
+script="$root/bin/rke2nodeinit-core.sh"
 
 if [[ ! -f "$script" ]]; then
   echo "Script not found: $script" >&2
@@ -21,7 +21,7 @@ if [[ "$missing_errors" -lt 3 ]]; then
   exit 1
 fi
 
-remediation_errors="$(grep -F -c 'log_error "Remediation: provide a readable absolute path or a path relative to the manifest/repository root."' "$script" || true)"
+remediation_errors="$(grep -F -c 'log_error "Remediation: ensure canonical token file exists and is readable at $CANONICAL_BOOTSTRAP_TOKEN_FILE."' "$script" || true)"
 if [[ "$remediation_errors" -lt 3 ]]; then
   echo "ERROR: Missing remediation guidance for one or more actions." >&2
   exit 1
@@ -72,13 +72,13 @@ if ! grep -Fq 'Runtime customCA seeding is offline-only. Populate helper during 
   exit 1
 fi
 
-if ! grep -Fq 'Using generated secure first-server token (custom CA fingerprint embedded).' "$script"; then
-  echo "ERROR: First-server generation path appears to be missing." >&2
+if grep -Fq 'Using generated secure first-server token (custom CA fingerprint embedded).' "$script"; then
+  echo "ERROR: Server generation fallback should not remain in strict canonical token-file mode." >&2
   exit 1
 fi
 
-if ! grep -Fq 'Using generated short first-server bootstrap token.' "$script"; then
-  echo "ERROR: First-server short token generation path appears to be missing." >&2
+if grep -Fq 'Using generated short first-server bootstrap token.' "$script"; then
+  echo "ERROR: Short server token generation fallback should not remain in strict canonical token-file mode." >&2
   exit 1
 fi
 

--- a/tests/test_token_yaml_key_normalization.sh
+++ b/tests/test_token_yaml_key_normalization.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 root="$(cd "$(dirname "$0")/.." && pwd -P)"
-script="$root/bin/rke2nodeinit.sh"
+script="$root/bin/rke2nodeinit-core.sh"
 render="$root/scripts/render_rke2_config.py"
 
 if [[ ! -f "$script" ]]; then

--- a/tests/test_tokenfile_paths.sh
+++ b/tests/test_tokenfile_paths.sh
@@ -4,41 +4,27 @@ set -euo pipefail
 root="$(cd "$(dirname "$0")/.." && pwd -P)"
 fail=0
 
-# tokenFile paths under /rke2-node-init/configs are not runtime-safe for cloned nodes.
-while IFS= read -r hit; do
-  [[ -n "$hit" ]] || continue
-  echo "ERROR: tokenFile points to /rke2-node-init/configs (should be /rke2-node-init/outputs): $hit"
-  fail=1
-done < <(grep -RIn "^[[:space:]]*tokenFile:[[:space:]]*/rke2-node-init/configs/" "$root/configs" "$root/clusters" 2>/dev/null || true)
+expected="/etc/rancher/rke2/token.d/bootstrap.token"
 
-# tokenFile paths must follow canonical nested contract under outputs.
+# tokenFile/token-file must always resolve to the canonical protected host path.
 while IFS= read -r hit; do
   [[ -n "$hit" ]] || continue
 
   token_path=""
-  if [[ "$hit" =~ tokenFile:[[:space:]]*([^[:space:]#]+) ]]; then
-    token_path="${BASH_REMATCH[1]}"
+  if [[ "$hit" =~ (tokenFile|token-file):[[:space:]]*([^[:space:]#]+) ]]; then
+    token_path="${BASH_REMATCH[2]}"
   fi
   [[ -n "$token_path" ]] || continue
 
-  if [[ "$token_path" != /rke2-node-init/outputs/*/*-bootstrap-token.txt ]]; then
-    echo "ERROR: tokenFile must match /rke2-node-init/outputs/<image>/<image>-bootstrap-token.txt: $hit"
-    fail=1
-    continue
-  fi
-
-  token_dir="$(basename -- "$(dirname -- "$token_path")")"
-  token_base="$(basename -- "$token_path")"
-  expected_base="${token_dir}-bootstrap-token.txt"
-  if [[ "$token_base" != "$expected_base" ]]; then
-    echo "ERROR: tokenFile basename must match parent image folder (${expected_base}): $hit"
+  if [[ "$token_path" != "$expected" ]]; then
+    echo "ERROR: token file reference must be $expected: $hit"
     fail=1
   fi
-done < <(grep -RIn "^[[:space:]]*tokenFile:[[:space:]]*/rke2-node-init/outputs/" "$root/configs" "$root/clusters" 2>/dev/null || true)
+done < <(grep -RIn "^[[:space:]]*(tokenFile|token-file):" "$root/configs" "$root/clusters" 2>/dev/null || true)
 
 if [[ "$fail" -ne 0 ]]; then
   echo "One or more tokenFile paths are invalid for first-boot runtime." >&2
   exit 1
 fi
 
-echo "All tokenFile paths use canonical /rke2-node-init/outputs/<image>/<image>-bootstrap-token.txt locations."
+echo "All tokenFile paths use canonical $expected location."

--- a/tests/test_tokenfile_paths.sh
+++ b/tests/test_tokenfile_paths.sh
@@ -20,7 +20,7 @@ while IFS= read -r hit; do
     echo "ERROR: token file reference must be $expected: $hit"
     fail=1
   fi
-done < <(grep -ERIn "^[[:space:]]*(tokenFile|token-file):" "$root/configs" "$root/clusters" 2>/dev/null || true)
+done < <(grep -RIn "^[[:space:]]*(tokenFile|token-file):" "$root/configs" "$root/clusters" 2>/dev/null || true)
 
 if [[ "$fail" -ne 0 ]]; then
   echo "One or more tokenFile paths are invalid for first-boot runtime." >&2

--- a/tests/test_tokenfile_paths.sh
+++ b/tests/test_tokenfile_paths.sh
@@ -20,7 +20,7 @@ while IFS= read -r hit; do
     echo "ERROR: token file reference must be $expected: $hit"
     fail=1
   fi
-done < <(grep -RIn "^[[:space:]]*(tokenFile|token-file):" "$root/configs" "$root/clusters" 2>/dev/null || true)
+done < <(grep -ERIn "^[[:space:]]*(tokenFile|token-file):" "$root/configs" "$root/clusters" 2>/dev/null || true)
 
 if [[ "$fail" -ne 0 ]]; then
   echo "One or more tokenFile paths are invalid for first-boot runtime." >&2


### PR DESCRIPTION
## Summary

This PR implements the bootstrap-token hardening and post-bootstrap cleanup plan end-to-end:

- Hard-cuts token retrieval to canonical protected host path: `/etc/rancher/rke2/token.d/bootstrap.token`.
- Enforces strict fail-fast behavior in `server`, `agent`, and `add-server` when canonical token file is missing/unreadable.
- Removes outputs-based bootstrap token artifact generation paths.
- Adds deferred, guarded repo cleanup after successful `server`/`agent`/`add-server` completion.
- Preserves operational artifacts before cleanup:
  - logs under `/var/log/rke2-node-init/<action>-<timestamp>/`
  - SBOM/metadata/security evidence under `/var/lib/rke2-node-init/artifacts/<action>-<timestamp>/`
- Migrates shipped node manifests to canonical `tokenFile` path.
- Updates docs, changelog, and CI checks.

## Key Changes

- Core token + cleanup behavior:
  - `bin/rke2nodeinit-core.sh`
- Token helper updates:
  - `Makefile`
  - `scripts/certs-auto.sh`
- Config migrations:
  - `configs/**` node manifests with `tokenFile`
- Tests:
  - `tests/test_tokenfile_paths.sh`
  - `tests/test_token_strict_policy.sh`
  - `tests/test_token_yaml_key_normalization.sh`
  - `tests/test_repo_cleanup_contract.sh` (new)
- CI:
  - `.github/workflows/verify-tokenfile.yml`
- Docs:
  - `docs/OPERATIONAL-RUNBOOK.md`
  - `docs/TROUBLESHOOTING.md`
  - `CHANGELOG.md`

## Validation

Executed locally:

- `bash tests/test_token_strict_policy.sh`
- `bash tests/test_tokenfile_paths.sh`
- `bash tests/test_token_yaml_key_normalization.sh`
- `bash tests/test_repo_cleanup_contract.sh`

All passed.
