### PR TITLE
Fix CIS kernel prerequisites before RKE2 startup

### DIFF
--- a/bin/rke2nodeinit-system.sh
+++ b/bin/rke2nodeinit-system.sh
@@ -3,6 +3,8 @@
 
 set -Eeuo pipefail
 
+RKE2NODEINIT_CIS_SYSCTL_FILE="${RKE2NODEINIT_CIS_SYSCTL_FILE:-/etc/sysctl.d/99-rke2-cis.conf}"
+
 rke2nodeinit_system_require_root() {
   if [[ ${EUID:-$(id -u)} -ne 0 ]]; then
     echo "ERROR: please run this command as root (use sudo)." >&2
@@ -28,4 +30,170 @@ rke2nodeinit_system_sysctl_set() {
   local value="${2:-}"
   [[ -n "$key" && -n "$value" ]] || return 2
   sysctl -w "${key}=${value}"
+}
+
+rke2nodeinit_system_manifest_requires_cis() {
+  local file="${1:-}"
+  [[ -n "$file" && -f "$file" ]] || return 1
+
+  if command -v python3 >/dev/null 2>&1; then
+    if python3 - "$file" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+values = {}
+stack = []
+scalar = re.compile(r'^(?P<indent>\s*)(?P<key>[A-Za-z0-9_.-]+)\s*:\s*(?P<value>.*?)\s*$')
+
+try:
+    lines = path.read_text(encoding='utf-8').splitlines()
+except OSError:
+    raise SystemExit(1)
+
+for raw in lines:
+    line = raw.split('#', 1)[0].rstrip()
+    if not line.strip() or line.lstrip().startswith('- '):
+        continue
+
+    match = scalar.match(line)
+    if not match:
+        continue
+
+    indent = len(match.group('indent'))
+    key = match.group('key')
+    value = match.group('value').strip()
+
+    while stack and stack[-1][0] >= indent:
+        stack.pop()
+
+    current = [part for _, part in stack] + [key]
+    dotted = '.'.join(current)
+
+    if value:
+        values[dotted] = value.strip('"\'')
+    else:
+        stack.append((indent, key))
+
+def truthy(value: str) -> bool:
+    return value.strip().lower() in {'1', 'true', 'yes', 'y', 'on', 'enabled'}
+
+profile = values.get('spec.profile', '').strip().lower()
+single_node_cis = values.get('spec.singleNode.enableCIS', '')
+generic_cis = values.get('spec.enableCIS', '')
+
+raise SystemExit(0 if profile == 'cis' or truthy(single_node_cis) or truthy(generic_cis) else 1)
+PY
+    then
+      return 0
+    fi
+    return 1
+  fi
+
+  if grep -Eiq '^[[:space:]]*profile[[:space:]]*:[[:space:]]*["'"'"']?cis["'"'"']?[[:space:]]*($|#)' "$file"; then
+    return 0
+  fi
+
+  if grep -Eiq '^[[:space:]]*enableCIS[[:space:]]*:[[:space:]]*(1|true|yes|y|on|enabled)([[:space:]]*($|#))' "$file"; then
+    return 0
+  fi
+
+  return 1
+}
+
+rke2nodeinit_system_config_requires_cis() {
+  local file
+  local -a candidates=("/etc/rancher/rke2/config.yaml")
+
+  for file in /etc/rancher/rke2/config.yaml.d/*.yaml /etc/rancher/rke2/config.yaml.d/*.yml; do
+    [[ -f "$file" ]] && candidates+=("$file")
+  done
+
+  for file in "${candidates[@]}"; do
+    [[ -f "$file" ]] || continue
+    if grep -Eiq '^[[:space:]]*profile[[:space:]]*:[[:space:]]*["'"'"']?cis["'"'"']?[[:space:]]*($|#)' "$file"; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+rke2nodeinit_system_apply_cis_kernel_prereqs() {
+  local sysctl_file="${RKE2NODEINIT_CIS_SYSCTL_FILE:-/etc/sysctl.d/99-rke2-cis.conf}"
+  local tmp=""
+  local key=""
+  local expected=""
+  local actual=""
+  local rc=0
+
+  rke2nodeinit_system_require_root || return 1
+
+  install -d -m 0755 "$(dirname -- "$sysctl_file")"
+  tmp="$(mktemp "${sysctl_file}.tmp.XXXXXX")"
+
+  cat > "$tmp" <<'EOF'
+# Managed by rke2-node-init.
+# Required by RKE2 when profile: cis enables protect-kernel-defaults.
+vm.overcommit_memory = 1
+vm.panic_on_oom = 0
+kernel.panic = 10
+kernel.panic_on_oops = 1
+EOF
+
+  install -m 0644 "$tmp" "$sysctl_file"
+  rm -f "$tmp"
+
+  while read -r key expected; do
+    [[ -n "$key" && -n "$expected" ]] || continue
+
+    if ! rke2nodeinit_system_sysctl_set "$key" "$expected" >/dev/null 2>&1; then
+      echo "ERROR: failed to apply RKE2 CIS kernel parameter ${key}=${expected}" >&2
+      rc=1
+      continue
+    fi
+
+    actual="$(sysctl -n "$key" 2>/dev/null || true)"
+    if [[ "$actual" != "$expected" ]]; then
+      echo "ERROR: invalid kernel parameter value ${key}=${actual:-<unreadable>} - expected ${expected}" >&2
+      rc=1
+    fi
+  done <<'EOF'
+vm.overcommit_memory 1
+vm.panic_on_oom 0
+kernel.panic 10
+kernel.panic_on_oops 1
+EOF
+
+  if [[ "$rc" -ne 0 ]]; then
+    echo "ERROR: RKE2 CIS kernel prerequisite enforcement failed; refusing to continue to RKE2 service startup." >&2
+    return "$rc"
+  fi
+
+  echo "[INFO] RKE2 CIS kernel prerequisites applied and persisted in ${sysctl_file}" >&2
+  return 0
+}
+
+rke2nodeinit_system_prepare_cis_for_action() {
+  local action="${1:-}"
+  local manifest="${2:-}"
+  local dry_run="${3:-0}"
+
+  case "$action" in
+    server|add-server|agent) ;;
+    *) return 0 ;;
+  esac
+
+  if ! rke2nodeinit_system_manifest_requires_cis "$manifest" && ! rke2nodeinit_system_config_requires_cis; then
+    return 0
+  fi
+
+  if [[ "$dry_run" == "1" ]]; then
+    echo "[INFO] DRY-RUN would apply RKE2 CIS kernel prerequisites: vm.overcommit_memory=1, vm.panic_on_oom=0, kernel.panic=10, kernel.panic_on_oops=1" >&2
+    return 0
+  fi
+
+  echo "[INFO] CIS profile detected for ${action}; applying RKE2 kernel prerequisites before service startup." >&2
+  rke2nodeinit_system_apply_cis_kernel_prereqs
 }

--- a/bin/rke2nodeinit.sh
+++ b/bin/rke2nodeinit.sh
@@ -14,6 +14,11 @@ umask 022
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 CORE_SCRIPT="${SCRIPT_DIR}/rke2nodeinit-core.sh"
 SINGLE_NODE_SCRIPT="${SCRIPT_DIR}/rke2nodeinit-single-node.sh"
+SYSTEM_HELPER="${SCRIPT_DIR}/rke2nodeinit-system.sh"
+
+[[ -f "$SYSTEM_HELPER" ]] || { echo "ERROR: Missing system helper: $SYSTEM_HELPER" >&2; exit 1; }
+# shellcheck source=bin/rke2nodeinit-system.sh
+source "$SYSTEM_HELPER"
 
 usage() {
   cat <<'USAGE'
@@ -35,6 +40,10 @@ Supported kind dispatch:
   Verify           -> verify
   Airgap           -> airgap
   CustomCA         -> custom-ca
+
+For Server, AddServer, Agent, and singleNodeServer manifests that enable the CIS
+profile, the dispatcher applies and persists the RKE2-required kernel parameters
+before handing control to the provisioning engine.
 
 Legacy action-first and option-first forms are both accepted:
   sudo bin/rke2nodeinit.sh image -f config.yaml -y
@@ -189,6 +198,18 @@ normalize_args() {
   done
 }
 
+normalized_args_contain() {
+  local needle="${1:-}"
+  local arg=""
+  [[ -n "$needle" ]] || return 1
+
+  for arg in "${NORMALIZED_ARGS[@]:-}"; do
+    [[ "$arg" == "$needle" ]] && return 0
+  done
+
+  return 1
+}
+
 exec_core() {
   [[ -x "$CORE_SCRIPT" ]] || { echo "ERROR: Missing executable core script: $CORE_SCRIPT" >&2; exit 1; }
   exec bash "$CORE_SCRIPT" "$@"
@@ -218,6 +239,8 @@ main() {
 
   local yaml_kind=""
   local resolved_action=""
+  local dry_run=0
+
   if [[ -n "${CONFIG_FILE:-}" && -f "$CONFIG_FILE" ]]; then
     yaml_kind="$(read_yaml_kind "$CONFIG_FILE" || true)"
     if [[ -n "$yaml_kind" ]]; then
@@ -225,12 +248,18 @@ main() {
     fi
   fi
 
-  if [[ -n "$yaml_kind" ]] && kind_is_single_node "$yaml_kind"; then
-    exec_single_node "$ACTION" "${NORMALIZED_ARGS[@]}"
-  fi
-
   if [[ -z "${ACTION:-}" && -n "$resolved_action" ]]; then
     ACTION="$resolved_action"
+  fi
+
+  if normalized_args_contain "--dry-run"; then
+    dry_run=1
+  fi
+
+  rke2nodeinit_system_prepare_cis_for_action "${ACTION:-}" "${CONFIG_FILE:-}" "$dry_run"
+
+  if [[ -n "$yaml_kind" ]] && kind_is_single_node "$yaml_kind"; then
+    exec_single_node "$ACTION" "${NORMALIZED_ARGS[@]}"
   fi
 
   if [[ -n "${ACTION:-}" ]]; then

--- a/docs/CIS-KERNEL-PREREQUISITES.md
+++ b/docs/CIS-KERNEL-PREREQUISITES.md
@@ -1,0 +1,147 @@
+# RKE2 CIS Kernel Prerequisites
+
+This document describes the host kernel parameters that `rke2-node-init` enforces when an RKE2 node is configured to use the CIS profile.
+
+## Why this exists
+
+RKE2 validates host kernel runtime parameters before starting when `profile: cis` is enabled. If the live kernel values do not match the RKE2 CIS requirements, `rke2-server` or `rke2-agent` exits before Kubernetes starts.
+
+A common failure is:
+
+```text
+invalid kernel parameter value vm.overcommit_memory=0 - expected 1
+```
+
+The Ubuntu default for `vm.overcommit_memory` may be `0`, while the RKE2 CIS profile requires `1`.
+
+## Required values
+
+`rke2-node-init` enforces and persists the following values:
+
+```text
+vm.overcommit_memory = 1
+vm.panic_on_oom = 0
+kernel.panic = 10
+kernel.panic_on_oops = 1
+```
+
+The persistent configuration is written to:
+
+```text
+/etc/sysctl.d/99-rke2-cis.conf
+```
+
+The values are also applied immediately with `sysctl` before control is handed to the RKE2 provisioning engine.
+
+## Automatic enforcement
+
+The public dispatcher, `bin/rke2nodeinit.sh`, performs CIS prerequisite preparation before the following actions:
+
+- `Server`
+- `AddServer`
+- `Agent`
+- `singleNodeServer`
+
+Enforcement is activated when either of these conditions is true:
+
+1. The supplied `rkeprep/v2` manifest declares `spec.profile: cis`.
+2. The supplied single-node manifest enables `spec.singleNode.enableCIS: true`.
+3. Existing RKE2 configuration under `/etc/rancher/rke2/config.yaml` or `/etc/rancher/rke2/config.yaml.d/` declares `profile: cis`.
+
+The dispatcher fails early if the required kernel values cannot be applied or verified. This is intentional: allowing provisioning to continue would only move the failure downstream to RKE2 startup.
+
+## Dry-run behavior
+
+When `--dry-run` is used, the dispatcher does not modify the host. It reports the exact CIS kernel values that would be applied.
+
+Example:
+
+```bash
+sudo bin/rke2nodeinit.sh -f server.yaml --dry-run -y
+```
+
+Expected message:
+
+```text
+DRY-RUN would apply RKE2 CIS kernel prerequisites: vm.overcommit_memory=1, vm.panic_on_oom=0, kernel.panic=10, kernel.panic_on_oops=1
+```
+
+## Manual remediation
+
+For a host that is already failing with a CIS kernel parameter error, apply the values manually:
+
+```bash
+sudo tee /etc/sysctl.d/99-rke2-cis.conf >/dev/null <<'EOF'
+# RKE2 CIS kernel runtime requirements
+vm.overcommit_memory = 1
+vm.panic_on_oom = 0
+kernel.panic = 10
+kernel.panic_on_oops = 1
+EOF
+
+sudo sysctl --system
+```
+
+Verify:
+
+```bash
+sysctl \
+  vm.overcommit_memory \
+  vm.panic_on_oom \
+  kernel.panic \
+  kernel.panic_on_oops
+```
+
+Expected output:
+
+```text
+vm.overcommit_memory = 1
+vm.panic_on_oom = 0
+kernel.panic = 10
+kernel.panic_on_oops = 1
+```
+
+Then restart the appropriate RKE2 service:
+
+```bash
+sudo systemctl restart rke2-server
+```
+
+or:
+
+```bash
+sudo systemctl restart rke2-agent
+```
+
+## Troubleshooting
+
+Check the live values:
+
+```bash
+sysctl -n vm.overcommit_memory
+sysctl -n vm.panic_on_oom
+sysctl -n kernel.panic
+sysctl -n kernel.panic_on_oops
+```
+
+Inspect persistent definitions:
+
+```bash
+grep -RInE \
+  'vm\.overcommit_memory|vm\.panic_on_oom|kernel\.panic|kernel\.panic_on_oops' \
+  /etc/sysctl.conf /etc/sysctl.d /usr/lib/sysctl.d 2>/dev/null
+```
+
+Inspect RKE2 startup logs:
+
+```bash
+sudo journalctl -u rke2-server -b --no-pager
+```
+
+or:
+
+```bash
+sudo journalctl -u rke2-agent -b --no-pager
+```
+
+If a later sysctl file overrides the managed values, remove or correct the conflicting definition so the effective runtime values remain aligned with the RKE2 CIS requirements.

--- a/tests/test-single-node-profile.sh
+++ b/tests/test-single-node-profile.sh
@@ -6,10 +6,35 @@ MAIN="${ROOT}/bin/rke2nodeinit.sh"
 CORE="${ROOT}/bin/rke2nodeinit-core.sh"
 SCRIPT="${ROOT}/bin/rke2-single-node-profile.sh"
 SINGLE_NODE_HELPER="${ROOT}/bin/rke2nodeinit-single-node.sh"
+SYSTEM_HELPER="${ROOT}/bin/rke2nodeinit-system.sh"
 IMAGE_CONFIG="${ROOT}/configs/single-node/golden-image.yaml"
 CONFIG="${ROOT}/configs/single-node/production-server.yaml"
 COTPA_IMAGE_CONFIG="${ROOT}/configs/cotpa-single-nodes/image-hyperv-v1.35.5+rke2r2-singlenode.yaml"
 COTPA_CONFIG="${ROOT}/configs/cotpa-single-nodes/nodes/dc1manager.yaml"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+CIS_CONFIG="${workdir}/cis-server.yaml"
+NON_CIS_CONFIG="${workdir}/non-cis-server.yaml"
+
+cat > "$CIS_CONFIG" <<'YAML'
+apiVersion: rkeprep/v2
+kind: Server
+metadata:
+  name: cis-server
+spec:
+  profile: cis
+YAML
+
+cat > "$NON_CIS_CONFIG" <<'YAML'
+apiVersion: rkeprep/v2
+kind: Server
+metadata:
+  name: non-cis-server
+spec:
+  profile: ""
+YAML
 
 bash -n "$MAIN"
 bash -n "$CORE"
@@ -19,17 +44,38 @@ bash -n "${ROOT}/bin/rke2nodeinit-config.sh"
 bash -n "${ROOT}/bin/rke2nodeinit-cni.sh"
 bash -n "${ROOT}/bin/rke2nodeinit-yaml.sh"
 bash -n "${ROOT}/bin/rke2nodeinit-router.sh"
-bash -n "${ROOT}/bin/rke2nodeinit-system.sh"
+bash -n "$SYSTEM_HELPER"
 
 grep -q 'CORE_SCRIPT=.*rke2nodeinit-core.sh' "$MAIN"
 grep -q 'SINGLE_NODE_SCRIPT=.*rke2nodeinit-single-node.sh' "$MAIN"
+grep -q 'SYSTEM_HELPER=.*rke2nodeinit-system.sh' "$MAIN"
 grep -q 'singleNodeImage  -> single-node image flow' "$MAIN"
 grep -q 'singleNodeServer -> single-node server flow' "$MAIN"
 grep -q 'RKE2NODEINIT_CORE_DELEGATE=1' "$MAIN"
+grep -q 'rke2nodeinit_system_prepare_cis_for_action' "$MAIN"
 grep -q 'RKE2NODEINIT_CORE_DELEGATE=1' "$SINGLE_NODE_HELPER"
 grep -q 'rke2-single-node-swap-preflight.sh' "$SINGLE_NODE_HELPER"
 grep -q '05-single-node-swap-preflight.conf' "$SINGLE_NODE_HELPER"
 grep -q 'swapoff -a' "$SINGLE_NODE_HELPER"
+
+grep -q 'rke2nodeinit_system_manifest_requires_cis' "$SYSTEM_HELPER"
+grep -q 'rke2nodeinit_system_apply_cis_kernel_prereqs' "$SYSTEM_HELPER"
+grep -q '99-rke2-cis.conf' "$SYSTEM_HELPER"
+grep -q 'vm.overcommit_memory = 1' "$SYSTEM_HELPER"
+grep -q 'vm.panic_on_oom = 0' "$SYSTEM_HELPER"
+grep -q 'kernel.panic = 10' "$SYSTEM_HELPER"
+grep -q 'kernel.panic_on_oops = 1' "$SYSTEM_HELPER"
+
+# shellcheck source=bin/rke2nodeinit-system.sh
+source "$SYSTEM_HELPER"
+
+rke2nodeinit_system_manifest_requires_cis "$CIS_CONFIG"
+rke2nodeinit_system_manifest_requires_cis "$COTPA_CONFIG"
+
+if rke2nodeinit_system_manifest_requires_cis "$NON_CIS_CONFIG"; then
+  echo "non-CIS manifest incorrectly detected as CIS" >&2
+  exit 1
+fi
 
 grep -q '^kind: singleNodeImage$' "$IMAGE_CONFIG"
 grep -q '^kind: singleNodeServer$' "$CONFIG"
@@ -51,6 +97,7 @@ done
 
 bash "$MAIN" --help | grep -q 'singleNodeImage'
 bash "$MAIN" --help | grep -q 'singleNodeServer'
+bash "$MAIN" --help | grep -q 'CIS'
 bash "$SCRIPT" --help | grep -q 'kind: singleNodeImage'
 bash "$SCRIPT" --help | grep -q 'kind: singleNodeServer'
 bash "$SCRIPT" --help | grep -q 'bin/rke2nodeinit.sh -f <rkeprep-yaml> image'
@@ -84,14 +131,17 @@ cotpa_image_dispatch="$(bash "$MAIN" -f "$COTPA_IMAGE_CONFIG" --dry-run -y 2>&1 
 grep -q 'bin/rke2nodeinit.sh --dry-run -y -f ' <<<"$cotpa_image_dispatch"
 grep -q ' image' <<<"$cotpa_image_dispatch"
 
+cis_dispatch="$(bash "$MAIN" -f "$CIS_CONFIG" --dry-run -y 2>&1 || true)"
+grep -q 'DRY-RUN would apply RKE2 CIS kernel prerequisites' <<<"$cis_dispatch"
+grep -q 'vm.overcommit_memory=1' <<<"$cis_dispatch"
+grep -q 'vm.panic_on_oom=0' <<<"$cis_dispatch"
+
 server_dispatch="$(bash "$MAIN" -f "$COTPA_CONFIG" --dry-run -y 2>&1 || true)"
+grep -q 'DRY-RUN would apply RKE2 CIS kernel prerequisites' <<<"$server_dispatch"
 grep -q 'DRY-RUN would install single-node swap preflight guard' <<<"$server_dispatch"
 grep -q 'DRY-RUN would install rke2-server ExecStartPre preflight guard' <<<"$server_dispatch"
 grep -q 'bin/rke2nodeinit.sh --dry-run -y -f ' <<<"$server_dispatch"
 grep -q ' server' <<<"$server_dispatch"
-
-workdir="$(mktemp -d)"
-trap 'rm -rf "$workdir"' EXIT
 
 bash "$SCRIPT" apply -f "$CONFIG" \
   --output-dir "$workdir/config.yaml.d" \


### PR DESCRIPTION
## Summary

This PR closes a CIS bootstrap gap in `rke2-node-init` that can cause RKE2 startup to fail with errors such as:

```text
invalid kernel parameter value vm.overcommit_memory=0 - expected 1
```

## Changes

- Add shared CIS profile detection for:
  - `spec.profile: cis`
  - `spec.singleNode.enableCIS: true`
  - `spec.enableCIS: true`
  - existing RKE2 config files under `/etc/rancher/rke2/config.yaml` and `config.yaml.d`
- Apply and persist the complete RKE2 CIS kernel baseline before `server`, `add-server`, `agent`, and `singleNodeServer` provisioning flows continue:
  - `vm.overcommit_memory = 1`
  - `vm.panic_on_oom = 0`
  - `kernel.panic = 10`
  - `kernel.panic_on_oops = 1`
- Verify applied values and fail closed before RKE2 service startup if enforcement fails.
- Add regression coverage for CIS, single-node CIS, non-CIS detection, and dry-run output.
- Add CIS kernel prerequisite documentation.

## Files changed

- `bin/rke2nodeinit-system.sh`
- `bin/rke2nodeinit.sh`
- `tests/test-single-node-profile.sh`
- `docs/CIS-KERNEL-PREREQUISITES.md`

## Design note

The change intentionally avoids modifying the large legacy `rke2nodeinit-core.sh`. CIS enforcement is centralized in the shared system helper and canonical public dispatcher to reduce regression risk and provide one consistent control point across supported RKE2 roles.

## Validation

Targeted validation covered:

- Bash syntax checks
- Standard `profile: cis` detection
- `singleNode.enableCIS: true` detection
- Non-CIS negative case
- Dry-run verification of the complete CIS kernel baseline

No GitHub Actions workflow was attached to the branch head at the time of validation.